### PR TITLE
[feat] renmae ai api key

### DIFF
--- a/backend/app/api/routes/ielts_router.py
+++ b/backend/app/api/routes/ielts_router.py
@@ -166,6 +166,15 @@ def get_api_key_list(
     return response
 
 
+@router.put("/api_keys/{api_key_id}/name", status_code=status.HTTP_204_NO_CONTENT)
+def rename_api_key(
+    db: SessionDep,
+    api_key_id: int,
+    request: user_api_key_schema.UserAPIKeyRenameRequest,
+) -> None:
+    user_api_key_crud.update_api_key_name(db, api_key_id, request.name)
+
+
 class FeedbackResponse(BaseModel):
     score: float
     feedback: str

--- a/backend/app/crud/user_api_key_crud.py
+++ b/backend/app/crud/user_api_key_crud.py
@@ -55,6 +55,15 @@ def update_last_used(db: Session, id: int):
     db.commit()
 
 
+def update_api_key_name(db: Session, id: int, name: str):
+    user_api_key = db.get(UserAPIKey, id)
+    if not user_api_key:
+        raise HTTPException(status_code=404, detail="API key not found")
+
+    user_api_key.name = name
+    db.commit()
+
+
 def update_to_be_inactive(db: Session, user_api_key: UserAPIKey):
     user_api_key.is_active = False
     db.commit()

--- a/backend/app/schemas/user_api_key_schema.py
+++ b/backend/app/schemas/user_api_key_schema.py
@@ -64,6 +64,16 @@ def generate_key_name():
     return f"secret-key_{datetime.now(timezone.utc).isoformat()}"
 
 
+class UserAPIKeyRenameRequest(BaseModel):
+    name: str
+
+    @field_validator("name")
+    def not_empty(cls, v):
+        if not v or not v.strip():
+            raise ValueError("null value is not allowed")
+        return v
+
+
 class UserAPIKeyCreate(BaseModel):
     user_id: int
     provider_id: int


### PR DESCRIPTION
### Summary

This PR implements the backend and frontend logic required to **rename an AI API key**. The change allows users to update the display name of their registered API keys via the UI.

### 🔧 Backend Changes

* **Endpoint Added**: `PUT /api_keys/{api_key_id}/name`
* **HTTP Status Code**: `204 No Content`
* **Reason for using `PUT` instead of `PATCH`**:

  * `PATCH` is currently unsupported by the frontend fetch logic (FastAPI adapter), so `PUT` is used temporarily. This can be reverted once support is added.

#### Implementation

```python
@router.put("/api_keys/{api_key_id}/name", status_code=status.HTTP_204_NO_CONTENT)
def rename_api_key(
    db: SessionDep,
    api_key_id: int,
    request: user_api_key_schema.UserAPIKeyRenameRequest
) -> None:
    user_api_key_crud.update_api_key_name(db, api_key_id, request.name)
```

### 💻 Frontend Changes

* Clicking the rename icon enters editing mode.
* Focus is automatically set to the input field.
* Submit on `Enter`, cancel on `Escape`.
* Prevent API call if:

  * Name is empty.
  * Name hasn't changed.
* After successful update:

  * Reset internal states.
  * Fetch the latest API key list to reflect the name change.

#### Key Snippet

```js
function renameApiKey(apiKey) {
  if (editingNameOfApiKey.trim() === '' || editingNameOfApiKey === apiKey.name) {
    return;
  }

  let url = `/api/v1/ielts/api_keys/${apiKey.id}/name`;
  let params = { name: editingNameOfApiKey };

  fastapi('put', url, params,
    (json) => {
      inputElement = null;
      editingNameOfApiKey = '';
      renameActiveIndex = null;
      getRegisteredAPIKeys();
    },
    (json_error) => {
      console.error("Error updating API key name:", json_error);
    }
  );
}
```

---

### 📝 Future Work

* Switch to `PATCH` once supported by frontend FastAPI fetch logic.
* Consider adding validation for uniqueness or maximum length on API key names (if applicable).

---

### ✅ Checklist

* [x] Backend endpoint implemented (`PUT`)
* [x] Frontend rename logic added and integrated
* [x] Prevents unnecessary network requests
* [x] Refreshes API key list after rename
