### PR TITLE
[feat] delete api key

### DIFF
--- a/backend/app/api/routes/ielts_router.py
+++ b/backend/app/api/routes/ielts_router.py
@@ -175,6 +175,11 @@ def rename_api_key(
     user_api_key_crud.update_api_key_name(db, api_key_id, request.name)
 
 
+@router.delete("/api_keys/{api_key_id}")
+def delete_api_key_route(db: SessionDep, api_key_id: int) -> None:
+    user_api_key_crud.delete_api_key(db, api_key_id)
+
+
 class FeedbackResponse(BaseModel):
     score: float
     feedback: str

--- a/backend/app/crud/user_api_key_crud.py
+++ b/backend/app/crud/user_api_key_crud.py
@@ -64,6 +64,15 @@ def update_api_key_name(db: Session, id: int, name: str):
     db.commit()
 
 
+def delete_api_key(db: Session, id: int):
+    user_api_key = db.get(UserAPIKey, id)
+    if not user_api_key:
+        raise HTTPException(status_code=404, detail="API key not found")
+
+    db.delete(user_api_key)
+    db.commit()
+
+
 def update_to_be_inactive(db: Session, user_api_key: UserAPIKey):
     user_api_key.is_active = False
     db.commit()

--- a/frontend/src/routes/IELTSFeedbackWriter.svelte
+++ b/frontend/src/routes/IELTSFeedbackWriter.svelte
@@ -34,7 +34,7 @@
   let APIKey = "";
   let registeredAPIKeys = [];
 
-  let selectedApiKey = null;
+  let activeApiKeyForDeleting = null;
 
   function cancel() {
     showManageKeyModalOpen = false;
@@ -364,7 +364,7 @@
   function openCheckDeleteApiKeyModal(apiKey){
     closePopup();
     checkDeleteApiModalOpen = true;
-    selectedApiKey = apiKey
+    activeApiKeyForDeleting = apiKey
   }
 
   let renameActiveIndex = null;
@@ -390,7 +390,7 @@
     if (editingNameOfApiKey.trim() === '' || editingNameOfApiKey === apiKey.name) {
       return
     }
-    // TODO: backend API key fetching
+    // TODO: [feat] add patch method in fastapi function
     let url = `/api/v1/ielts/api_keys/${apiKey.id}/name`;
     let params = { name:  editingNameOfApiKey};
 
@@ -409,9 +409,6 @@
   function closeCheckDeleteApiKeyModal(){
     checkDeleteApiModalOpen = false;
   }
-  function deleteApiKey(apiKey){
-    openCheckDeleteApiKeyModal(apiKey)
-  }
 
   function cancelEdit() {
     inputElement=null;
@@ -421,14 +418,23 @@
   }
 
   function confirmDeleteApiKey(){
-    secretKeys = secretKeys.filter(k => k.id !== selectedApiKey.id);
-    selectedApiKey = null;
-    checkDeleteApiModalOpen = false;
+
+    let url = `/api/v1/ielts/api_keys/${activeApiKeyForDeleting.id}`;
+    let params = {};
+    fastapi('delete', url, params,
+      (json) => {
+        activeApiKeyForDeleting = null;
+        checkDeleteApiModalOpen = false;
+        getRegisteredAPIKeys();
+      },
+      (json_error) => {
+        console.error("Error deleting API key name:", json_error);
+      }
+    );
   }
+
   let activePopupId = null
   let popupContainer;
-
-
   function closePopup() {
     activePopupId = null;
     if (popupContainer) {
@@ -913,7 +919,7 @@
         </div>
         <div class="modal-body">
           <h5>Are you sure you want to delete
-            <strong>{selectedApiKey?.name}</strong>
+            <strong>{activeApiKeyForDeleting?.name}</strong>
             ? This action cannot be undone.</h5>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
### Description

This PR adds the ability for users to delete a registered API key. The flow includes:

* Opening a confirmation modal on delete action.
* Sending a `DELETE` request to the backend upon user confirmation.
* Removing the API key from the database.
* Refreshing the API key list in the frontend UI after deletion.

### 🛠️ Backend

* Added `DELETE /api_keys/{api_key_id}` route
* Implemented `delete_api_key()` logic in `user_api_key_crud`:

  * Fetch the API key by ID
  * Raise `404` if not found:

    ```python
    raise HTTPException(status_code=404, detail="API key not found")
    ```
  * Delete the key and commit the transaction
 
### 🖥️ Frontend

* Added `confirmDeleteApiKey()` method to handle:

  * API call to delete the key
  * Modal state reset
  * Refreshing the API key list (`getRegisteredAPIKeys`)