### PR TITLE
[fix] feed incorrect ai input(essay_student -> essay_student.content)

### DIFF
--- a/backend/app/api/routes/ielts_router.py
+++ b/backend/app/api/routes/ielts_router.py
@@ -242,7 +242,7 @@ async def trigger_feedback_generation(
             criterion_name, sub_system_prompts.get(criterion_name, ""), rubric_text
         )
         llm_prompt = llm_prompt.format(
-            essay_prompt=request.prompt, student_essay=student_essay
+            essay_prompt=request.prompt, student_essay=student_essay.content
         )
 
         llm_response = client.responses.parse(


### PR DESCRIPTION
### **Description:**

This PR fixes a bug where the full `student_essay` object was mistakenly passed to the AI component, instead of just the essay's content. The incorrect assignment likely led to unexpected behaviour or errors during processing.

### 🔧 Changes Made

```diff
- student_essay = student_essay
+ student_essay = student_essay.content
```

### ✅ Why This Fix Is Needed

The AI expects a plain string input (the essay content), not an object. Passing the full object could result in:

* Improper formatting
* Type errors
* Irrelevant AI responses

### 📎 Notes

* Consider adding input validation in the AI entry point to assert input types.
* Might be worth writing a test case specifically to catch this mistake in the future.
