### PR TITLE
refactor(test-db): migrate test DB from named volume to tmpfs

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -7,11 +7,12 @@ services:
       retries: 5
       start_period: 30s
       timeout: 10s
-    volumes: []
+    volumes:
+      - /var/lib/postgresql/data/pgdata
     tmpfs:
-      - /var/lib/postgresql/data/pgdata:mode=0700,uid=999,gid=999
+      - /var/lib/postgresql/data/test-pgdata:mode=0700,uid=999,gid=999
     environment:
-      - PGDATA=/var/lib/postgresql/data/pgdata
+      - PGDATA=/var/lib/postgresql/data/test-pgdata
       - POSTGRES_PASSWORD=${TEST_POSTGRES_PASSWORD?Variable not set}
       - POSTGRES_USER=${TEST_POSTGRES_USER?Variable not set}
       - POSTGRES_DB=${TEST_POSTGRES_DB?Variable not set}


### PR DESCRIPTION
## Summary
- Replace the named volume (`test-db-data`) with RAM-backed `tmpfs` for the test PostgreSQL database
- Explicitly override the base compose file's `app-db-data` volume with an anonymous volume at the same target path
- Use a separate `PGDATA` path (`test-pgdata`) to avoid volume/tmpfs mount conflicts
- Remove the top-level `volumes: test-db-data:` declaration

## Motivation
Eliminates the structural risk of volume name misconfiguration accidentally overwriting the production database. With tmpfs, test data lives only in RAM and is destroyed when the container stops.

## How it works
Docker Compose merges volume lists by target path. To prevent the base `app-db-data:/var/lib/postgresql/data/pgdata` from being inherited:
1. An anonymous volume overrides `app-db-data` at the same target (`/var/lib/postgresql/data/pgdata`)
2. `tmpfs` is mounted at a separate path (`/var/lib/postgresql/data/test-pgdata`)
3. `PGDATA` points to the tmpfs path, so PostgreSQL uses only RAM-backed storage

Closes #69

## Test plan
- [ ] `docker compose -f docker-compose.yml -f docker-compose.test.yaml up -d db` starts successfully
- [ ] `docker volume ls | grep test-db-data` returns nothing
- [ ] Backend tests pass with the tmpfs-backed test DB
- [ ] CI workflows remain green (no changes needed — `docker compose down -v` is harmless with tmpfs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)