### PR TITLE
⬆ bump GitHub Actions: checkout@v6, upload-artifact@v7, download-artifact@v8

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,7 +24,7 @@ jobs:
       POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD_PRODUCTION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Create .env file
         run: |
           echo "ENVIRONMENT=production" >> .env

--- a/.github/workflows/smokeshow.yml
+++ b/.github/workflows/smokeshow.yml
@@ -14,12 +14,12 @@ jobs:
       statuses: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - run: pip install smokeshow
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           name: coverage-html
           path: backend/htmlcov

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -17,7 +17,7 @@ jobs:
       COMPOSE_FILE: docker-compose.yaml:docker-compose.override.yaml:docker-compose.test.yaml
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -68,7 +68,7 @@ jobs:
         run: docker compose exec -T backend bash /app/scripts/test.sh
       - run: docker compose down -v --remove-orphans
       - name: Store coverage files
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-html
           path: backend/htmlcov

--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -17,7 +17,7 @@ jobs:
       COMPOSE_FILE: docker-compose.yaml:docker-compose.override.yaml:docker-compose.test.yaml
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Create .env file
         run: |


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v5 to v6 (all workflows)
- Bump `actions/upload-artifact` from v5 to v7 (`test-backend.yml`)
- Bump `actions/download-artifact` from v6 to v8 (`smokeshow.yml`)

Consolidates Dependabot PRs #64, #65, #66 into a single update. The individual PRs failed CI because each only bumped one action while the workflows depend on compatible versions across all three (especially the upload/download artifact pair in test-backend → smokeshow).

### Compatibility notes
- All three bumps are driven by the Node.js 24 runtime upgrade
- `upload-artifact@v7` defaults to zipped uploads (same as v5) — no change needed
- `download-artifact@v8` adds `digest-mismatch: error` by default (stricter, catches corruption)
- `checkout@v6` persists credentials to `$RUNNER_TEMP` — requires runner >= v2.329.0 for self-hosted (deploy job)

### Supersedes
- #64 (upload-artifact v5→v7)
- #65 (checkout v5→v6)
- #66 (download-artifact v6→v8)

## Test plan
- [x] CI passes on this PR (`test-backend`, `test-docker-compose`, `alls-green`)
- [x] Close #64, #65, #66 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)