### PR TITLE
refactor(backend): convert sync SQLAlchemy to async

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,5 +1,5 @@
 import os
-from collections.abc import Generator
+from collections.abc import AsyncGenerator
 from typing import Annotated
 
 from dotenv import load_dotenv
@@ -7,10 +7,10 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt, ExpiredSignatureError
 from pydantic import ValidationError
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.core.db import engine
+from app.core.db import AsyncSessionLocal
 from app.crud import user_crud
 from app.models import User
 
@@ -19,23 +19,19 @@ load_dotenv()
 ALGORITHM = os.getenv("ALGORITHM")
 
 
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 reusable_oauth2 = OAuth2PasswordBearer(tokenUrl=f"{settings.API_V1_STR}/user/login")
 
 
-def get_db() -> Generator[Session, None, None]:
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async with AsyncSessionLocal() as session:
+        yield session
 
 
-SessionDep = Annotated[Session, Depends(get_db)]
+SessionDep = Annotated[AsyncSession, Depends(get_db)]
 TokenDep = Annotated[str, Depends(reusable_oauth2)]
 
 
-def get_current_user(db: SessionDep, token: TokenDep) -> User:
+async def get_current_user(db: SessionDep, token: TokenDep) -> User:
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
         user_email = payload.get("sub")
@@ -50,7 +46,7 @@ def get_current_user(db: SessionDep, token: TokenDep) -> User:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Could not validate credentials",
         )
-    user = user_crud.get_user_by_email(db, email=user_email)
+    user = await user_crud.get_user_by_email(db, email=user_email)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return user

--- a/backend/app/api/routes/ielts_router.py
+++ b/backend/app/api/routes/ielts_router.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from datetime import datetime, timezone
 from pathlib import Path
@@ -37,49 +38,53 @@ router = APIRouter()
 
 
 @router.post("/create", status_code=status.HTTP_204_NO_CONTENT)
-def prompt_create(prompt_in: prompt_schema.PromptCreate, db: SessionDep) -> None:
-    prompt_crud.create_prompt(db=db, prompt_create=prompt_in)
+async def prompt_create(prompt_in: prompt_schema.PromptCreate, db: SessionDep) -> None:
+    await prompt_crud.create_prompt(db=db, prompt_create=prompt_in)
 
 
 @router.get("/prompts", response_model=list[prompt_schema.Prompt])
-def get_prompts(db: SessionDep) -> list[prompt_schema.Prompt]:
-    prompt_list = prompt_crud.get_prompts(db)
+async def get_prompts(db: SessionDep) -> list[prompt_schema.Prompt]:
+    prompt_list = await prompt_crud.get_prompts(db)
     return prompt_list
 
 
 @router.get("/example", response_model=example_essay_schema.ExampleEssay)
-def get_example_by_prompt_id(
+async def get_example_by_prompt_id(
     db: SessionDep, prompt_id: int
 ) -> example_essay_schema.ExampleEssay:
-    example_essay = example_essay_crud.get_example_essay_by_prompt_id(db, prompt_id)
+    example_essay = await example_essay_crud.get_example_essay_by_prompt_id(
+        db, prompt_id
+    )
     return example_essay
 
 
 @router.get(
     "/criteria", response_model=list[rubric_criterion_schema.RubricCriterionPublic]
 )
-def get_rubric_criteria(
+async def get_rubric_criteria(
     db: SessionDep, name: str
 ) -> list[rubric_criterion_schema.RubricCriterionPublic]:
-    rubric = rubric_crud.get_rubric_by_name(db, name)
+    rubric = await rubric_crud.get_rubric_by_name(db, name)
     rubric_criteria = sorted(rubric.criteria, key=lambda x: x.id)
 
     return rubric_criteria
 
 
 @router.get("/essays", response_model=list[essay_schema.EssayPublic])
-def get_essays_by_prompt_id(
+async def get_essays_by_prompt_id(
     db: SessionDep, current_user: CurrentUser, prompt_id: int
 ) -> list[essay_schema.EssayPublic]:
-    essay_list = essay_crud.get_essay_list_by_prompt_id(db, current_user.id, prompt_id)
+    essay_list = await essay_crud.get_essay_list_by_prompt_id(
+        db, current_user.id, prompt_id
+    )
     return essay_list
 
 
 @router.get("/feedbacks", response_model=list[feedback_schema.FeedbackPublic])
-def get_feedbacks_by_user_prompt(
+async def get_feedbacks_by_user_prompt(
     db: SessionDep, current_user: CurrentUser, prompt_id: int, essay_id: int
 ) -> list[feedback_schema.FeedbackPublic]:
-    db_feedback_list = feedback_crud.get_feedbacks_by_user_prompt_essay(
+    db_feedback_list = await feedback_crud.get_feedbacks_by_user_prompt_essay(
         db, current_user.id, prompt_id, essay_id
     )
     feedback_list = []
@@ -92,29 +97,29 @@ def get_feedbacks_by_user_prompt(
 
 
 @router.get("/bots", response_model=list[bot_schema.BotPublic])
-def read_bots(db: SessionDep) -> list[bot_schema.BotPublic]:
-    return bot_crud.get_bots(db)
+async def read_bots(db: SessionDep) -> list[bot_schema.BotPublic]:
+    return await bot_crud.get_bots(db)
 
 
 @router.get("/providers", response_model=list[ai_provider_schema.AIProviderPublic])
-def read_providers(db: SessionDep) -> list[ai_provider_schema.AIProviderPublic]:
-    return ai_provider_crud.get_providers(db)
+async def read_providers(db: SessionDep) -> list[ai_provider_schema.AIProviderPublic]:
+    return await ai_provider_crud.get_providers(db)
 
 
 @router.get(
     "/api_models/{provider_name}", response_model=list[api_model_schema.APIModelPublic]
 )
-def read_api_models(
+async def read_api_models(
     db: SessionDep, provider_name: str
 ) -> list[api_model_schema.APIModelPublic]:
-    return api_model_crud.get_api_models_by_provider(db, provider_name)
+    return await api_model_crud.get_api_models_by_provider(db, provider_name)
 
 
 @router.post("/essays")
-def submit_essay(
+async def submit_essay(
     db: SessionDep, current_user: CurrentUser, request: essay_schema.EssayCreateRequest
 ) -> essay_schema.Essay:
-    essay = essay_crud.get_duplicated_essay(
+    essay = await essay_crud.get_duplicated_essay(
         db, current_user.id, request.prompt_id, request.content
     )
     if essay is None:
@@ -124,46 +129,46 @@ def submit_essay(
             content=request.content,
             submitted_at=datetime.now(),
         )
-        essay = essay_crud.create_essay(db, essay_create)
+        essay = await essay_crud.create_essay(db, essay_create)
 
     return essay
 
 
 @router.post("/essays/handwriting")
-def submit_handwriting_essay(
+async def submit_handwriting_essay(
     db: SessionDep,
     current_user: CurrentUser,
     prompt_id: int,
     image: UploadFile = File(...),
 ) -> essay_schema.Essay:
     max_bytes = settings.MAX_UPLOAD_SIZE_MB * 1024 * 1024
-    contents = image.file.read()
+    contents = await image.read()
     if len(contents) > max_bytes:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             detail=f"Image exceeds {settings.MAX_UPLOAD_SIZE_MB}MB limit",
         )
 
-    db_essay = essay_crud.create_handwriting_essay(
+    db_essay = await essay_crud.create_handwriting_essay(
         db, current_user.id, prompt_id, datetime.now(timezone.utc)
     )
 
     upload_dir = Path(settings.UPLOAD_DIR) / "essays" / str(current_user.id)
     upload_dir.mkdir(parents=True, exist_ok=True)
     file_path = upload_dir / f"{db_essay.id}.png"
-    file_path.write_bytes(contents)
+    await asyncio.to_thread(file_path.write_bytes, contents)
 
-    essay_crud.update_essay_image_path(db, db_essay.id, str(file_path))
+    await essay_crud.update_essay_image_path(db, db_essay.id, str(file_path))
 
-    db.refresh(db_essay)
+    await db.refresh(db_essay)
     return essay_schema.Essay.model_validate(db_essay)
 
 
 @router.get("/essays/{essay_id}/image")
-def get_essay_image(
+async def get_essay_image(
     db: SessionDep, current_user: CurrentUser, essay_id: int
 ) -> FileResponse:
-    essay = essay_crud.get_essay_by_id(db, essay_id)
+    essay = await essay_crud.get_essay_by_id(db, essay_id)
     if essay is None or essay.user_id != current_user.id:
         raise HTTPException(status_code=404, detail="Essay not found")
     if not essay.image_path or not os.path.isfile(essay.image_path):
@@ -176,25 +181,28 @@ def generate_key_name():
 
 
 @router.post("/api_keys", status_code=status.HTTP_204_NO_CONTENT)
-def create_api_key(
+async def create_api_key(
     db: SessionDep,
     current_user: CurrentUser,
     request: user_api_key_schema.UserAPIKeyCreateRequest,
 ):
+    provider = await ai_provider_crud.get_provider_by_name(db, request.provider_name)
     user_api_key_create = user_api_key_schema.UserAPIKeyCreate(
         user_id=current_user.id,
-        provider_id=ai_provider_crud.get_provider_by_name(db, request.provider_name).id,
+        provider_id=provider.id,
         name=request.name or generate_key_name(),
         api_key=security.encrypt_api_key(request.api_key),
     )
-    _ = user_api_key_crud.create_user_api_key(db, user_api_key_create)
+    _ = await user_api_key_crud.create_user_api_key(db, user_api_key_create)
 
 
 @router.get("/api_keys", response_model=list[user_api_key_schema.UserAPIKeyPublic])
-def get_api_key_list(
+async def get_api_key_list(
     db: SessionDep, current_user: CurrentUser
 ) -> list[user_api_key_schema.UserAPIKeyPublic]:
-    user_api_key_list = user_api_key_crud.get_user_api_key_list(db, current_user.id)
+    user_api_key_list = await user_api_key_crud.get_user_api_key_list(
+        db, current_user.id
+    )
     response = []
     for user_api_key in user_api_key_list:
         item = user_api_key_schema.UserAPIKeyPublic(
@@ -211,17 +219,17 @@ def get_api_key_list(
 
 
 @router.put("/api_keys/{api_key_id}/name", status_code=status.HTTP_204_NO_CONTENT)
-def rename_api_key(
+async def rename_api_key(
     db: SessionDep,
     api_key_id: int,
     request: user_api_key_schema.UserAPIKeyRenameRequest,
 ) -> None:
-    user_api_key_crud.update_api_key_name(db, api_key_id, request.name)
+    await user_api_key_crud.update_api_key_name(db, api_key_id, request.name)
 
 
 @router.delete("/api_keys/{api_key_id}")
-def delete_api_key_route(db: SessionDep, api_key_id: int) -> None:
-    user_api_key_crud.delete_api_key(db, api_key_id)
+async def delete_api_key_route(db: SessionDep, api_key_id: int) -> None:
+    await user_api_key_crud.delete_api_key(db, api_key_id)
 
 
 @router.post("/essays/{essay_id}/feedback")
@@ -231,12 +239,12 @@ async def trigger_feedback_generation(
     essay_id: int,
     request: feedback_schema.FeedbackCreateRequest,
 ) -> None:
-    essay = essay_crud.get_essay_by_id(db, essay_id)
+    essay = await essay_crud.get_essay_by_id(db, essay_id)
     if essay is None:
         raise HTTPException(status_code=404, detail="Essay not found")
     if essay.input_type.value == "handwriting":
-        feedback_service.generate_feedback_for_handwriting(
+        await feedback_service.generate_feedback_for_handwriting(
             db, current_user.id, essay_id, request
         )
     else:
-        feedback_service.generate_feedback(db, current_user.id, essay_id, request)
+        await feedback_service.generate_feedback(db, current_user.id, essay_id, request)

--- a/backend/app/api/routes/user_router.py
+++ b/backend/app/api/routes/user_router.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import timedelta
 from typing import Annotated
 
@@ -16,16 +17,16 @@ router = APIRouter()
 
 
 @router.get("/auth")
-def check_auth(current_user: CurrentUser):
+async def check_auth(current_user: CurrentUser):
     return {"status": "authenticated"}
 
 
 @router.post("/login", response_model=user_schema.Token)
-def login_access_token(
+async def login_access_token(
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
     db: SessionDep,
 ) -> user_schema.Token:
-    user = user_crud.authenticate(
+    user = await user_crud.authenticate(
         db=db, email=form_data.username, password=form_data.password
     )
     if not user:
@@ -45,20 +46,20 @@ def login_access_token(
 
 
 @router.post("/create", status_code=status.HTTP_204_NO_CONTENT)
-def user_create(user_in: user_schema.UserCreate, db: SessionDep) -> None:
-    user = user_crud.get_user_by_email(db, email=user_in.email)
+async def user_create(user_in: user_schema.UserCreate, db: SessionDep) -> None:
+    user = await user_crud.get_user_by_email(db, email=user_in.email)
     if user:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT, detail="The user already exists."
         )
-    user_crud.create_user(db=db, user_create=user_in)
+    await user_crud.create_user(db=db, user_create=user_in)
 
 
 @router.post("/password", status_code=status.HTTP_204_NO_CONTENT)
 async def request_reset_password(
     user_email: user_schema.UserEmail, db: SessionDep
 ) -> None:
-    user = user_crud.get_user_by_email(db, email=user_email.email)
+    user = await user_crud.get_user_by_email(db, email=user_email.email)
 
     if not user:
         raise HTTPException(
@@ -70,7 +71,8 @@ async def request_reset_password(
     email_data = user_utils.generate_reset_password_email(
         email_to=user.email, email=user_email.email, token=password_reset_token
     )
-    user_utils.send_email(
+    await asyncio.to_thread(
+        user_utils.send_email,
         email_to=user.email,
         subject=email_data.subject,
         html_content=email_data.html_content,
@@ -78,18 +80,18 @@ async def request_reset_password(
 
 
 @router.post("/reset-password")
-def reset_password(db: SessionDep, body: user_schema.NewPassword) -> None:
+async def reset_password(db: SessionDep, body: user_schema.NewPassword) -> None:
     """
     Reset password
     """
     email = user_utils.verify_password_reset_token(token=body.token)
     if not email:
         raise HTTPException(status_code=400, detail="Invalid token")
-    user = user_crud.get_user_by_email(db=db, email=email)
+    user = await user_crud.get_user_by_email(db=db, email=email)
     if not user:
         raise HTTPException(
             status_code=404,
             detail="The user with this email does not exist in the system.",
         )
     hashed_password = security.get_password_hash(password=body.new_password)
-    user_crud.update_user_password(db, user, hashed_password)
+    await user_crud.update_user_password(db, user, hashed_password)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -87,6 +87,13 @@ class Settings(BaseSettings):
             path=self.POSTGRES_DB,
         )
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def ASYNC_SQLALCHEMY_DATABASE_URI(self) -> str:
+        return str(self.SQLALCHEMY_DATABASE_URI).replace(
+            "postgresql+psycopg://", "postgresql+psycopg_async://", 1
+        )
+
     SMTP_TLS: bool = True
     SMTP_SSL: bool = False
     SMTP_PORT: int = SMTP_PORT

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -1,6 +1,6 @@
 import logging
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 import os
 import csv
@@ -8,6 +8,7 @@ from typing import Any
 from datetime import datetime
 
 from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from app.core.config import settings
 
 from app.core.security import encrypt_api_key
@@ -40,24 +41,21 @@ logger = logging.getLogger(__name__)
 
 engine = create_engine(str(settings.SQLALCHEMY_DATABASE_URI))
 
+async_engine = create_async_engine(str(settings.ASYNC_SQLALCHEMY_DATABASE_URI))
+AsyncSessionLocal = async_sessionmaker(
+    async_engine, class_=AsyncSession, expire_on_commit=False
+)
 
-def init_db(db: Session) -> None:
-    # Tables should be created with Alembic migrations
-    # But if you don't want to use migrations, create
-    # the tables un-commenting the next lines
-    # from sqlmodel import SQLModel
 
-    # This works because the models are already imported and registered from app.models
-    # SQLModel.metadata.create_all(engine)
-
-    user = user_crud.get_user_by_email(db, settings.FIRST_SUPERUSER)
+async def init_db(db: AsyncSession) -> None:
+    user = await user_crud.get_user_by_email(db, settings.FIRST_SUPERUSER)
     if not user:
         user_create = user_schema.UserCreate(
             email=settings.FIRST_SUPERUSER,
             is_superuser=True,
             password=settings.FIRST_SUPERUSER_PASSWORD,
         )
-        user_crud.create_user(db, user_create)
+        await user_crud.create_user(db, user_create)
 
 
 def load_from_csv(csv_path: str) -> list[dict[str, Any]]:
@@ -72,14 +70,16 @@ def load_from_csv(csv_path: str) -> list[dict[str, Any]]:
     return data
 
 
-def store_example_essays(db: Session, csv_path: str) -> None:
+async def store_example_essays(db: AsyncSession, csv_path: str) -> None:
     data = load_from_csv(csv_path)
-    super_user = user_crud.get_user_by_email(db, settings.FIRST_SUPERUSER)
+    super_user = await user_crud.get_user_by_email(db, settings.FIRST_SUPERUSER)
     for item in data:
         prompt_content = item["prompt"].strip()
         example_answer = item["example_answer"].strip()
 
-        existing_prompt = prompt_crud.get_prompt_by_content(db, content=prompt_content)
+        existing_prompt = await prompt_crud.get_prompt_by_content(
+            db, content=prompt_content
+        )
         if not existing_prompt:
             prompt_create = prompt_schema.PromptCreate(
                 content=prompt_content,
@@ -87,9 +87,9 @@ def store_example_essays(db: Session, csv_path: str) -> None:
                 created_at=datetime.now(),
                 updated_at=datetime.now(),
             )
-            db_prompt = prompt_crud.create_prompt(db, prompt_create)
+            db_prompt = await prompt_crud.create_prompt(db, prompt_create)
 
-            existing_example = example_essay_crud.get_example_essay_by_content(
+            existing_example = await example_essay_crud.get_example_essay_by_content(
                 db, example_answer
             )
             if not existing_example:
@@ -100,18 +100,20 @@ def store_example_essays(db: Session, csv_path: str) -> None:
                     updated_at=datetime.now(),
                 )
 
-                _ = example_essay_crud.create_example_essay(db, example_essay_create)
+                _ = await example_essay_crud.create_example_essay(
+                    db, example_essay_create
+                )
 
 
-def store_default_rubric(
-    db: Session, csv_path: str, rubric_create: rubric_schema.RubricCreate
+async def store_default_rubric(
+    db: AsyncSession, csv_path: str, rubric_create: rubric_schema.RubricCreate
 ) -> None:
     data = load_from_csv(csv_path)
-    existing_rubric = rubric_crud.get_rubric_by_name(db, rubric_create.name)
+    existing_rubric = await rubric_crud.get_rubric_by_name(db, rubric_create.name)
     if not existing_rubric:
-        super_user = user_crud.get_user_by_email(db, settings.FIRST_SUPERUSER)
+        super_user = await user_crud.get_user_by_email(db, settings.FIRST_SUPERUSER)
         rubric_create.created_by = super_user.id
-        db_rubric = rubric_crud.create_rubric(db, rubric_create)
+        db_rubric = await rubric_crud.create_rubric(db, rubric_create)
 
         for row in data:
             score = row.pop("score")
@@ -122,7 +124,7 @@ def store_default_rubric(
 
             for _criterion_name, _description in row.items():
                 existing_criterion = (
-                    rubric_criterion_crud.get_criterion_by_name_and_score(
+                    await rubric_criterion_crud.get_criterion_by_name_and_score(
                         db=db, name=_criterion_name, score=score
                     )
                 )
@@ -133,41 +135,41 @@ def store_default_rubric(
                         description=_description,
                         score=score,
                     )
-                    _ = rubric_criterion_crud.create_rubric_criterion(
+                    _ = await rubric_criterion_crud.create_rubric_criterion(
                         db, criterion_create
                     )
 
 
-def store_default_bots(db: Session, csv_path: str) -> None:
+async def store_default_bots(db: AsyncSession, csv_path: str) -> None:
     data = load_from_csv(csv_path)
     for row in data:
-        existing_bot = bot_crud.get_bot_by_name(db, row["name"].strip())
+        existing_bot = await bot_crud.get_bot_by_name(db, row["name"].strip())
         if not existing_bot:
             bot_create = bot_schema.BotCreate(
                 name=row["name"].strip(),
                 version=row.get("version").strip(),
                 description=row.get("description").strip(),
             )
-            bot_crud.create_bot(db, bot_create)
+            await bot_crud.create_bot(db, bot_create)
 
 
-def store_default_ai_providers(db: Session, csv_path: str) -> None:
+async def store_default_ai_providers(db: AsyncSession, csv_path: str) -> None:
     data = load_from_csv(csv_path)
     for row in data:
-        existing_provider = ai_provider_crud.get_provider_by_name(
+        existing_provider = await ai_provider_crud.get_provider_by_name(
             db, provider_name=row["provider_name"]
         )
         if not existing_provider:
             ai_provider_create = ai_provider_schema.AIProviderCreate(
                 name=row["provider_name"]
             )
-            ai_provider_crud.create_provider(db, ai_provider_create)
+            await ai_provider_crud.create_provider(db, ai_provider_create)
 
 
-def store_default_api_models(db: Session, csv_path: str) -> None:
+async def store_default_api_models(db: AsyncSession, csv_path: str) -> None:
     data = load_from_csv(csv_path)
     for row in data:
-        existing_api_model = api_model_crud.get_api_model_by_name_and_provider(
+        existing_api_model = await api_model_crud.get_api_model_by_name_and_provider(
             db, api_model_name=row["api_model_name"], provider_name=row["provider_name"]
         )
         if not existing_api_model:
@@ -176,11 +178,11 @@ def store_default_api_models(db: Session, csv_path: str) -> None:
                 alias=row.get("alias"),
                 provider_name=row["provider_name"],
             )
-            api_model_crud.create_api_model(db, api_model_create)
+            await api_model_crud.create_api_model(db, api_model_create)
 
 
-def store_default_api_key(db: Session) -> None:
-    super_user = user_crud.get_user_by_email(db, settings.FIRST_SUPERUSER)
+async def store_default_api_key(db: AsyncSession) -> None:
+    super_user = await user_crud.get_user_by_email(db, settings.FIRST_SUPERUSER)
 
     api_keys = [
         ("OPENAI_API_KEY", "OpenAI"),
@@ -192,11 +194,11 @@ def store_default_api_key(db: Session) -> None:
         if not api_key_value:
             continue
 
-        provider = ai_provider_crud.get_provider_by_name(db, provider_name)
+        provider = await ai_provider_crud.get_provider_by_name(db, provider_name)
         if not provider:
             continue
 
-        existing_key = user_api_key_crud.get_user_api_key(
+        existing_key = await user_api_key_crud.get_user_api_key(
             db,
             super_user.id,
             provider_id=provider.id,
@@ -209,4 +211,4 @@ def store_default_api_key(db: Session) -> None:
                 name=env_var,
                 api_key=encrypt_api_key(api_key_value),
             )
-            user_api_key_crud.create_user_api_key(db, user_api_key_create)
+            await user_api_key_crud.create_user_api_key(db, user_api_key_create)

--- a/backend/app/crud/ai_provider_crud.py
+++ b/backend/app/crud/ai_provider_crud.py
@@ -1,27 +1,30 @@
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import AIProvider
 from app.schemas import ai_provider_schema
 
 
-def get_provider_by_name(
-    db: Session, provider_name: str
+async def get_provider_by_name(
+    db: AsyncSession, provider_name: str
 ) -> ai_provider_schema.AIProvider:
-    api_model = db.query(AIProvider).filter(AIProvider.name == provider_name).first()
-    return api_model
+    result = await db.execute(
+        select(AIProvider).where(AIProvider.name == provider_name)
+    )
+    return result.scalars().first()
 
 
-def create_provider(
-    db: Session, provider_create: ai_provider_schema.AIProviderCreate
+async def create_provider(
+    db: AsyncSession, provider_create: ai_provider_schema.AIProviderCreate
 ) -> ai_provider_schema.AIProvider:
     new_ai_provider = AIProvider(name=provider_create.name)
     db.add(new_ai_provider)
-    db.commit()
-    db.refresh(new_ai_provider)
+    await db.commit()
+    await db.refresh(new_ai_provider)
 
     return ai_provider_schema.AIProvider.from_orm(new_ai_provider)
 
 
-def get_providers(db: Session) -> list[ai_provider_schema.AIProvider]:
-    providers = db.query(AIProvider).all()
-    return providers
+async def get_providers(db: AsyncSession) -> list[ai_provider_schema.AIProvider]:
+    result = await db.execute(select(AIProvider))
+    return result.scalars().all()

--- a/backend/app/crud/api_model_crud.py
+++ b/backend/app/crud/api_model_crud.py
@@ -1,59 +1,61 @@
-from sqlalchemy.orm import Session
-from sqlalchemy import and_
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.crud import ai_provider_crud, bot_crud
 from app.models import APIModel, AIProvider
 from app.schemas import api_model_schema
 
 
-def get_api_model_by_alias(db: Session, alias: str) -> api_model_schema.APIModel:
-    api_model = db.query(APIModel).filter(APIModel.alias == alias).first()
-    return api_model
+async def get_api_model_by_alias(
+    db: AsyncSession, alias: str
+) -> api_model_schema.APIModel:
+    result = await db.execute(select(APIModel).where(APIModel.alias == alias))
+    return result.scalars().first()
 
 
-def get_api_models_by_provider(
-    db: Session, provider_name: str
+async def get_api_models_by_provider(
+    db: AsyncSession, provider_name: str
 ) -> list[api_model_schema.APIModel]:
-    api_models = (
-        db.query(APIModel)
-        .join(AIProvider)
-        .filter(AIProvider.name == provider_name)
-        .all()
+    result = await db.execute(
+        select(APIModel).join(AIProvider).where(AIProvider.name == provider_name)
     )
+    return result.scalars().all()
 
-    return api_models
 
-
-def get_api_model_by_name_and_provider(
-    db: Session, api_model_name: str, provider_name: str
+async def get_api_model_by_name_and_provider(
+    db: AsyncSession, api_model_name: str, provider_name: str
 ) -> api_model_schema.APIModel | None:
-    return (
-        db.query(APIModel)
+    result = await db.execute(
+        select(APIModel)
+        .options(selectinload(APIModel.bot))
         .join(AIProvider)
-        .filter(
+        .where(
             and_(
                 AIProvider.name == provider_name,
                 APIModel.api_model_name == api_model_name,
             )
         )
-        .first()
     )
+    return result.scalars().first()
 
 
-def create_api_model(
-    db: Session, api_model_create: api_model_schema.APIModelCreate
+async def create_api_model(
+    db: AsyncSession, api_model_create: api_model_schema.APIModelCreate
 ) -> api_model_schema.APIModel:
+    bot = await bot_crud.get_bot_by_name(db, api_model_create.alias)
+    provider = await ai_provider_crud.get_provider_by_name(
+        db, api_model_create.provider_name
+    )
     new_api_model = APIModel(
-        bot_id=bot_crud.get_bot_by_name(db, api_model_create.alias).id,
-        provider_id=ai_provider_crud.get_provider_by_name(
-            db, api_model_create.provider_name
-        ).id,
+        bot_id=bot.id,
+        provider_id=provider.id,
         api_model_name=api_model_create.api_model_name,
         alias=api_model_create.alias,
     )
 
     db.add(new_api_model)
-    db.commit()
-    db.refresh(new_api_model)
+    await db.commit()
+    await db.refresh(new_api_model)
 
     return api_model_schema.APIModel.from_orm(new_api_model)

--- a/backend/app/crud/bot_crud.py
+++ b/backend/app/crud/bot_crud.py
@@ -1,20 +1,23 @@
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Bot
 from app.schemas import bot_schema
 
 
-def get_bot_by_name(db: Session, name: str) -> Bot:
-    bot = db.query(Bot).filter(Bot.name == name).first()
-    return bot
+async def get_bot_by_name(db: AsyncSession, name: str) -> Bot:
+    result = await db.execute(select(Bot).where(Bot.name == name))
+    return result.scalars().first()
 
 
-def get_bots(db: Session) -> list[bot_schema.Bot]:
-    bot = db.query(Bot).all()
-    return bot
+async def get_bots(db: AsyncSession) -> list[bot_schema.Bot]:
+    result = await db.execute(select(Bot))
+    return result.scalars().all()
 
 
-def create_bot(db: Session, create_bot: bot_schema.BotCreate) -> bot_schema.Bot:
+async def create_bot(
+    db: AsyncSession, create_bot: bot_schema.BotCreate
+) -> bot_schema.Bot:
     db_bot = Bot(
         name=create_bot.name,
         version=create_bot.version,
@@ -22,7 +25,7 @@ def create_bot(db: Session, create_bot: bot_schema.BotCreate) -> bot_schema.Bot:
         deprecated=False,
     )
     db.add(db_bot)
-    db.commit()
-    db.refresh(db_bot)
+    await db.commit()
+    await db.refresh(db_bot)
 
     return bot_schema.Bot.from_orm(db_bot)

--- a/backend/app/crud/essay_crud.py
+++ b/backend/app/crud/essay_crud.py
@@ -1,6 +1,6 @@
 import re
-from sqlalchemy import and_, desc
-from sqlalchemy.orm import Session
+from sqlalchemy import and_, desc, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Essay, InputType
 from app.schemas import essay_schema
@@ -10,8 +10,8 @@ def normalise_content(content: str) -> str:
     return re.sub(r"\s+", " ", content.strip())
 
 
-def create_essay(
-    db: Session, essay_create: essay_schema.EssayCreate
+async def create_essay(
+    db: AsyncSession, essay_create: essay_schema.EssayCreate
 ) -> essay_schema.Essay:
     db_essay = Essay(
         user_id=essay_create.user_id,
@@ -20,37 +20,36 @@ def create_essay(
         submitted_at=essay_create.submitted_at,
     )
     db.add(db_essay)
-    db.commit()
-    db.refresh(db_essay)
+    await db.commit()
+    await db.refresh(db_essay)
 
     return essay_schema.Essay.from_orm(db_essay)
 
 
-def get_essay_by_id(db: Session, id: int) -> essay_schema.Essay:
-    essay = db.query(Essay).filter(Essay.id == id).first()
-    return essay
+async def get_essay_by_id(db: AsyncSession, id: int) -> essay_schema.Essay:
+    result = await db.execute(select(Essay).where(Essay.id == id))
+    return result.scalars().first()
 
 
-def get_duplicated_essay(
-    db: Session, user_id: int, prompt_id: int, content: str
+async def get_duplicated_essay(
+    db: AsyncSession, user_id: int, prompt_id: int, content: str
 ) -> essay_schema.Essay | None:
-    db_essays = (
-        db.query(Essay)
-        .filter(
+    result = await db.execute(
+        select(Essay).where(
             and_(
                 Essay.user_id == user_id,
                 Essay.prompt_id == prompt_id,
             )
         )
-        .all()
     )
+    db_essays = result.scalars().all()
     for db_essay in db_essays:
         if normalise_content(db_essay.content) == normalise_content(content):
             return db_essay
 
 
-def create_handwriting_essay(
-    db: Session, user_id: int, prompt_id: int, submitted_at
+async def create_handwriting_essay(
+    db: AsyncSession, user_id: int, prompt_id: int, submitted_at
 ) -> Essay:
     db_essay = Essay(
         user_id=user_id,
@@ -59,28 +58,33 @@ def create_handwriting_essay(
         submitted_at=submitted_at,
     )
     db.add(db_essay)
-    db.commit()
-    db.refresh(db_essay)
+    await db.commit()
+    await db.refresh(db_essay)
     return db_essay
 
 
-def update_essay_image_path(db: Session, essay_id: int, image_path: str) -> None:
-    db.query(Essay).filter(Essay.id == essay_id).update({"image_path": image_path})
-    db.commit()
-
-
-def update_ocr_text(db: Session, essay_id: int, ocr_text: str) -> None:
-    db.query(Essay).filter(Essay.id == essay_id).update({"ocr_text": ocr_text})
-    db.commit()
-
-
-def get_essay_list_by_prompt_id(
-    db: Session, user_id: int, prompt_id: int
-) -> list[essay_schema.EssayPublic]:
-    essay_list = (
-        db.query(Essay)
-        .filter(and_(Essay.user_id == user_id, Essay.prompt_id == prompt_id))
-        .order_by(desc(Essay.submitted_at))
-        .all()
+async def update_essay_image_path(
+    db: AsyncSession, essay_id: int, image_path: str
+) -> None:
+    await db.execute(
+        update(Essay).where(Essay.id == essay_id).values(image_path=image_path)
     )
-    return essay_list
+    await db.commit()
+
+
+async def update_ocr_text(db: AsyncSession, essay_id: int, ocr_text: str) -> None:
+    await db.execute(
+        update(Essay).where(Essay.id == essay_id).values(ocr_text=ocr_text)
+    )
+    await db.commit()
+
+
+async def get_essay_list_by_prompt_id(
+    db: AsyncSession, user_id: int, prompt_id: int
+) -> list[essay_schema.EssayPublic]:
+    result = await db.execute(
+        select(Essay)
+        .where(and_(Essay.user_id == user_id, Essay.prompt_id == prompt_id))
+        .order_by(desc(Essay.submitted_at))
+    )
+    return result.scalars().all()

--- a/backend/app/crud/example_essay_crud.py
+++ b/backend/app/crud/example_essay_crud.py
@@ -1,12 +1,13 @@
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.crud import prompt_crud
 from app.models import ExampleEssay
 from app.schemas import example_essay_schema
 
 
-def create_example_essay(
-    db: Session, example_essay_create: example_essay_schema.ExampleEssayCreate
+async def create_example_essay(
+    db: AsyncSession, example_essay_create: example_essay_schema.ExampleEssayCreate
 ) -> ExampleEssay:
     db_example_essay = ExampleEssay(
         prompt_id=example_essay_create.prompt_id,
@@ -15,26 +16,28 @@ def create_example_essay(
         updated_at=example_essay_create.updated_at,
     )
     db.add(db_example_essay)
-    db.commit()
+    await db.commit()
     return db_example_essay
 
 
-def get_example_essay(db: Session, id: int) -> ExampleEssay:
-    example_essay = db.query(ExampleEssay).filter(ExampleEssay.id == id).first()
-    return example_essay
+async def get_example_essay(db: AsyncSession, id: int) -> ExampleEssay:
+    result = await db.execute(select(ExampleEssay).where(ExampleEssay.id == id))
+    return result.scalars().first()
 
 
-def get_example_essay_by_content(db: Session, content: str) -> ExampleEssay:
-    example_essay = (
-        db.query(ExampleEssay).filter(ExampleEssay.content == content).first()
+async def get_example_essay_by_content(db: AsyncSession, content: str) -> ExampleEssay:
+    result = await db.execute(
+        select(ExampleEssay).where(ExampleEssay.content == content)
     )
-    return example_essay
+    return result.scalars().first()
 
 
-def get_example_essay_by_prompt_id(db: Session, prompt_id: int) -> ExampleEssay:
-    prompt = prompt_crud.get_prompt_by_id(db, prompt_id)
+async def get_example_essay_by_prompt_id(
+    db: AsyncSession, prompt_id: int
+) -> ExampleEssay:
+    prompt = await prompt_crud.get_prompt_by_id(db, prompt_id)
     if prompt:
-        example_essay = (
-            db.query(ExampleEssay).filter(ExampleEssay.prompt_id == prompt.id).first()
+        result = await db.execute(
+            select(ExampleEssay).where(ExampleEssay.prompt_id == prompt.id)
         )
-        return example_essay
+        return result.scalars().first()

--- a/backend/app/crud/feedback_crud.py
+++ b/backend/app/crud/feedback_crud.py
@@ -1,12 +1,13 @@
-from sqlalchemy import and_, desc
-from sqlalchemy.orm import Session
+from sqlalchemy import and_, desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.models import Feedback
 from app.schemas import feedback_schema
 
 
-def create_feedback(
-    db: Session, feedback_create: feedback_schema.FeedbackCreate
+async def create_feedback(
+    db: AsyncSession, feedback_create: feedback_schema.FeedbackCreate
 ) -> feedback_schema.Feedback:
     db_feedback = Feedback(
         user_id=feedback_create.user_id,
@@ -17,18 +18,19 @@ def create_feedback(
         created_at=feedback_create.created_at,
     )
     db.add(db_feedback)
-    db.commit()
-    db.refresh(db_feedback)
+    await db.commit()
+    await db.refresh(db_feedback)
 
     return feedback_schema.Feedback.from_orm(db_feedback)
 
 
-def get_feedbacks_by_user_prompt_essay(
-    db: Session, user_id: int, prompt_id: int, essay_id: int
+async def get_feedbacks_by_user_prompt_essay(
+    db: AsyncSession, user_id: int, prompt_id: int, essay_id: int
 ) -> list[Feedback]:
-    db_feedback_list = (
-        db.query(Feedback)
-        .filter(
+    result = await db.execute(
+        select(Feedback)
+        .options(selectinload(Feedback.bot))
+        .where(
             and_(
                 Feedback.user_id == user_id,
                 Feedback.prompt_id == prompt_id,
@@ -36,6 +38,5 @@ def get_feedbacks_by_user_prompt_essay(
             )
         )
         .order_by(desc(Feedback.created_at))
-        .all()
     )
-    return db_feedback_list
+    return result.scalars().all()

--- a/backend/app/crud/prompt_crud.py
+++ b/backend/app/crud/prompt_crud.py
@@ -1,10 +1,14 @@
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.models import Prompt
 from app.schemas import prompt_schema
 
 
-def create_prompt(db: Session, prompt_create: prompt_schema.PromptCreate) -> Prompt:
+async def create_prompt(
+    db: AsyncSession, prompt_create: prompt_schema.PromptCreate
+) -> Prompt:
     db_prompt = Prompt(
         content=prompt_create.content,
         created_by=prompt_create.created_by,
@@ -12,19 +16,20 @@ def create_prompt(db: Session, prompt_create: prompt_schema.PromptCreate) -> Pro
         updated_at=prompt_create.updated_at,
     )
     db.add(db_prompt)
-    db.commit()
+    await db.commit()
     return db_prompt
 
 
-def get_prompts(db: Session) -> list[Prompt]:
-    prompts = db.query(Prompt).all()
-    return prompts
+async def get_prompts(db: AsyncSession) -> list[Prompt]:
+    result = await db.execute(select(Prompt).options(selectinload(Prompt.reactions)))
+    return result.scalars().all()
 
 
-def get_prompt_by_content(db: Session, content: str) -> Prompt:
-    prompt = db.query(Prompt).filter(Prompt.content == content.strip()).first()
-    return prompt
+async def get_prompt_by_content(db: AsyncSession, content: str) -> Prompt:
+    result = await db.execute(select(Prompt).where(Prompt.content == content.strip()))
+    return result.scalars().first()
 
 
-def get_prompt_by_id(db: Session, prompt_id: int) -> Prompt | None:
-    return db.query(Prompt).filter(Prompt.id == prompt_id).first()
+async def get_prompt_by_id(db: AsyncSession, prompt_id: int) -> Prompt | None:
+    result = await db.execute(select(Prompt).where(Prompt.id == prompt_id))
+    return result.scalars().first()

--- a/backend/app/crud/rubric_criterion_crud.py
+++ b/backend/app/crud/rubric_criterion_crud.py
@@ -1,12 +1,13 @@
-from sqlalchemy.orm import Session
-from sqlalchemy import and_, desc, distinct
+from sqlalchemy import and_, desc, distinct, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import RubricCriterion, Rubric
 from app.schemas import rubric_criterion_schema
 
 
-def create_rubric_criterion(
-    db: Session, rubric_create_criterion: rubric_criterion_schema.RubricCriterionCreate
+async def create_rubric_criterion(
+    db: AsyncSession,
+    rubric_create_criterion: rubric_criterion_schema.RubricCriterionCreate,
 ) -> rubric_criterion_schema.RubricCriterion:
     db_rubric_criterion = RubricCriterion(
         rubric_id=rubric_create_criterion.rubric_id,
@@ -15,41 +16,39 @@ def create_rubric_criterion(
         score=rubric_create_criterion.score,
     )
     db.add(db_rubric_criterion)
-    db.commit()
+    await db.commit()
     return db_rubric_criterion
 
 
-def get_criterion_by_name_and_score(
-    db: Session, name: str, score: int
+async def get_criterion_by_name_and_score(
+    db: AsyncSession, name: str, score: int
 ) -> rubric_criterion_schema.RubricCriterion:
-    rubric_criterion = (
-        db.query(RubricCriterion)
-        .filter(
+    result = await db.execute(
+        select(RubricCriterion).where(
             and_(RubricCriterion.name == name.strip(), RubricCriterion.score == score)
         )
-        .first()
     )
-    return rubric_criterion
+    return result.scalars().first()
 
 
-def get_criterion_by_name(
-    db: Session, criteria_name: str
+async def get_criterion_by_name(
+    db: AsyncSession, criteria_name: str
 ) -> list[rubric_criterion_schema.RubricCriterion]:
-    rubric_criteria = (
-        db.query(RubricCriterion)
-        .filter(RubricCriterion.name == criteria_name.strip())
+    result = await db.execute(
+        select(RubricCriterion)
+        .where(RubricCriterion.name == criteria_name.strip())
         .order_by(desc(RubricCriterion.score))
-        .all()
     )
-    return rubric_criteria
+    return result.scalars().all()
 
 
-def get_unique_criterion_names_by_rubric(db: Session, rubric_name: str) -> list[str]:
-    names = (
-        db.query(distinct(RubricCriterion.name))
+async def get_unique_criterion_names_by_rubric(
+    db: AsyncSession, rubric_name: str
+) -> list[str]:
+    result = await db.execute(
+        select(distinct(RubricCriterion.name))
         .join(Rubric)
-        .filter(Rubric.name == rubric_name)
-        .all()
+        .where(Rubric.name == rubric_name)
     )
 
-    return [name[0] for name in names]
+    return [name for (name,) in result.all()]

--- a/backend/app/crud/rubric_crud.py
+++ b/backend/app/crud/rubric_crud.py
@@ -1,11 +1,13 @@
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.models import Rubric
 from app.schemas import rubric_schema
 
 
-def create_rubric(
-    db: Session, rubric_create: rubric_schema.RubricCreate
+async def create_rubric(
+    db: AsyncSession, rubric_create: rubric_schema.RubricCreate
 ) -> rubric_schema.Rubric:
     db_rubric = Rubric(
         name=rubric_create.name,
@@ -17,10 +19,14 @@ def create_rubric(
         created_by=rubric_create.created_by,
     )
     db.add(db_rubric)
-    db.commit()
+    await db.commit()
     return db_rubric
 
 
-def get_rubric_by_name(db: Session, name: str) -> rubric_schema.Rubric:
-    rubric = db.query(Rubric).filter(Rubric.name == name.strip()).first()
-    return rubric
+async def get_rubric_by_name(db: AsyncSession, name: str) -> rubric_schema.Rubric:
+    result = await db.execute(
+        select(Rubric)
+        .options(selectinload(Rubric.criteria))
+        .where(Rubric.name == name.strip())
+    )
+    return result.scalars().first()

--- a/backend/app/crud/user_api_key_crud.py
+++ b/backend/app/crud/user_api_key_crud.py
@@ -1,14 +1,15 @@
 from datetime import datetime, timezone
-from sqlalchemy import and_
-from sqlalchemy.orm import Session
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from fastapi import HTTPException
 from app.models import UserAPIKey
 from app.schemas import user_api_key_schema
 
 
-def create_user_api_key(
-    db: Session, user_api_key_create: user_api_key_schema.UserAPIKeyCreate
+async def create_user_api_key(
+    db: AsyncSession, user_api_key_create: user_api_key_schema.UserAPIKeyCreate
 ) -> user_api_key_schema.UserAPIKey:
     db_user_api_key = UserAPIKey(
         user_id=user_api_key_create.user_id,
@@ -18,61 +19,63 @@ def create_user_api_key(
         registered_at=user_api_key_create.registered_at,
     )
     db.add(db_user_api_key)
-    db.commit()
-    db.refresh(db_user_api_key)
+    await db.commit()
+    await db.refresh(db_user_api_key)
 
     return user_api_key_schema.UserAPIKey.from_orm(db_user_api_key)
 
 
-def get_user_api_key(
-    db: Session, user_id, provider_id
+async def get_user_api_key(
+    db: AsyncSession, user_id, provider_id
 ) -> user_api_key_schema.UserAPIKey:
-    db_api_key = (
-        db.query(UserAPIKey)
-        .filter(
+    result = await db.execute(
+        select(UserAPIKey).where(
             and_(
                 UserAPIKey.user_id == user_id,
                 UserAPIKey.provider_id == provider_id,
                 UserAPIKey.is_active,
             )
         )
-        .first()
     )
-    return db_api_key
+    return result.scalars().first()
 
 
-def get_user_api_key_list(db: Session, user_id) -> list[UserAPIKey]:
-    api_key_list = db.query(UserAPIKey).filter(UserAPIKey.user_id == user_id).all()
-    return api_key_list
+async def get_user_api_key_list(db: AsyncSession, user_id) -> list[UserAPIKey]:
+    result = await db.execute(
+        select(UserAPIKey)
+        .options(selectinload(UserAPIKey.provider))
+        .where(UserAPIKey.user_id == user_id)
+    )
+    return result.scalars().all()
 
 
-def update_last_used(db: Session, id: int):
-    user_api_key = db.get(UserAPIKey, id)
+async def update_last_used(db: AsyncSession, id: int):
+    user_api_key = await db.get(UserAPIKey, id)
     if not user_api_key:
         raise HTTPException(status_code=404, detail="API key not found")
 
     user_api_key.last_used = datetime.now(timezone.utc)
-    db.commit()
+    await db.commit()
 
 
-def update_api_key_name(db: Session, id: int, name: str):
-    user_api_key = db.get(UserAPIKey, id)
+async def update_api_key_name(db: AsyncSession, id: int, name: str):
+    user_api_key = await db.get(UserAPIKey, id)
     if not user_api_key:
         raise HTTPException(status_code=404, detail="API key not found")
 
     user_api_key.name = name
-    db.commit()
+    await db.commit()
 
 
-def delete_api_key(db: Session, id: int):
-    user_api_key = db.get(UserAPIKey, id)
+async def delete_api_key(db: AsyncSession, id: int):
+    user_api_key = await db.get(UserAPIKey, id)
     if not user_api_key:
         raise HTTPException(status_code=404, detail="API key not found")
 
-    db.delete(user_api_key)
-    db.commit()
+    await db.delete(user_api_key)
+    await db.commit()
 
 
-def update_to_be_inactive(db: Session, user_api_key: UserAPIKey):
+async def update_to_be_inactive(db: AsyncSession, user_api_key: UserAPIKey):
     user_api_key.is_active = False
-    db.commit()
+    await db.commit()

--- a/backend/app/crud/user_crud.py
+++ b/backend/app/crud/user_crud.py
@@ -1,31 +1,33 @@
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import get_password_hash, verify_password
 from app.models import User
 from app.schemas import user_schema
 
 
-def create_user(db: Session, user_create: user_schema.UserCreate) -> None:
+async def create_user(db: AsyncSession, user_create: user_schema.UserCreate) -> None:
     db_user = User(
         email=user_create.email,
         is_superuser=user_create.is_superuser,
         password=get_password_hash(user_create.password),
     )
     db.add(db_user)
-    db.commit()
+    await db.commit()
 
 
-def get_user_by_email(db: Session, email: str) -> User | None:
-    return db.query(User).filter(User.email == email).first()
+async def get_user_by_email(db: AsyncSession, email: str) -> User | None:
+    result = await db.execute(select(User).where(User.email == email))
+    return result.scalars().first()
 
 
-def update_user_password(db: Session, user: User, new_password: str) -> None:
+async def update_user_password(db: AsyncSession, user: User, new_password: str) -> None:
     user.password = new_password
-    db.commit()
+    await db.commit()
 
 
-def authenticate(db: Session, email: str, password: str) -> User | None:
-    db_user = get_user_by_email(db=db, email=email)
+async def authenticate(db: AsyncSession, email: str, password: str) -> User | None:
+    db_user = await get_user_by_email(db=db, email=email)
     if not db_user:
         return None
     if not verify_password(password, db_user.password):

--- a/backend/app/initial_data.py
+++ b/backend/app/initial_data.py
@@ -1,8 +1,8 @@
+import asyncio
 import logging
-from sqlalchemy.orm import Session
 
 from app.core.db import (
-    engine,
+    AsyncSessionLocal,
     init_db,
     store_example_essays,
     store_default_rubric,
@@ -17,10 +17,10 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def init() -> None:
-    with Session(engine) as session:
-        init_db(session)
-        store_example_essays(session, "app/data/ielts/example_essays.csv")
+async def init() -> None:
+    async with AsyncSessionLocal() as session:
+        await init_db(session)
+        await store_example_essays(session, "app/data/ielts/example_essays.csv")
 
         rubric_create = rubric_schema.RubricCreate(
             name="IELTS Writing Task 2",
@@ -28,20 +28,20 @@ def init() -> None:
             language="en",
             scoring_method="average",
         )
-        store_default_rubric(
+        await store_default_rubric(
             session,
             "app/data/ielts/IELTS_writing_task_2_band_descriptions.csv",
             rubric_create,
         )
-        store_default_bots(session, "app/data/bots.csv")
-        store_default_ai_providers(session, "app/data/AI_provider.csv")
-        store_default_api_models(session, "app/data/API_Model.csv")
-        store_default_api_key(session)
+        await store_default_bots(session, "app/data/bots.csv")
+        await store_default_ai_providers(session, "app/data/AI_provider.csv")
+        await store_default_api_models(session, "app/data/API_Model.csv")
+        await store_default_api_key(session)
 
 
 def main() -> None:
     logger.info("Creating initial data")
-    init()
+    asyncio.run(init())
     logger.info("Initial data created")
 
 

--- a/backend/app/services/feedback_service.py
+++ b/backend/app/services/feedback_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 from datetime import datetime, timezone
 from pathlib import Path
@@ -9,7 +10,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.runnables import Runnable
 from langchain_openai import ChatOpenAI
 from pydantic import BaseModel
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core import security
 from app.crud import (
@@ -79,25 +80,27 @@ def get_llm_prompt_for_ielts_holistic_feedback(
     return IELTS_HOLISTIC_SYSTEM_PROMPT, human_prompt
 
 
-def generate_feedback(
-    db: Session,
+async def generate_feedback(
+    db: AsyncSession,
     user_id: int,
     essay_id: int,
     request: feedback_schema.FeedbackCreateRequest,
     override_content: str | None = None,
 ) -> None:
-    student_essay = essay_crud.get_essay_by_id(db, essay_id)
-    criterion_names = rubric_criterion_crud.get_unique_criterion_names_by_rubric(
+    student_essay = await essay_crud.get_essay_by_id(db, essay_id)
+    criterion_names = await rubric_criterion_crud.get_unique_criterion_names_by_rubric(
         db, request.rubric_name
     )
 
-    db_provider = ai_provider_crud.get_provider_by_name(db, request.model_provider_name)
+    db_provider = await ai_provider_crud.get_provider_by_name(
+        db, request.model_provider_name
+    )
     if db_provider is None:
         raise HTTPException(
             status_code=404,
             detail=f"Unknown provider: {request.model_provider_name}",
         )
-    db_api_key = user_api_key_crud.get_user_api_key(db, user_id, db_provider.id)
+    db_api_key = await user_api_key_crud.get_user_api_key(db, user_id, db_provider.id)
     if db_api_key is None:
         raise HTTPException(
             status_code=404,
@@ -111,7 +114,9 @@ def generate_feedback(
     holistic_feedback_inputs: dict[str, str] = {}
 
     for criterion_name in criterion_names:
-        criterion_list = rubric_criterion_crud.get_criterion_by_name(db, criterion_name)
+        criterion_list = await rubric_criterion_crud.get_criterion_by_name(
+            db, criterion_name
+        )
         rubric_text = "\n".join(
             f"- **{criterion.score}**: {criterion.description}"
             for criterion in criterion_list
@@ -124,7 +129,7 @@ def generate_feedback(
             essay_prompt=request.prompt, student_essay=essay_text
         )
 
-        result: FeedbackResponse = structured_llm.invoke(
+        result: FeedbackResponse = await structured_llm.ainvoke(
             [SystemMessage(content=system_prompt), HumanMessage(content=human_prompt)]
         )
 
@@ -139,17 +144,17 @@ def generate_feedback(
         holistic_feedback_inputs
     )
 
-    holistic_result: FeedbackResponse = structured_llm.invoke(
+    holistic_result: FeedbackResponse = await structured_llm.ainvoke(
         [SystemMessage(content=holistic_system), HumanMessage(content=holistic_human)]
     )
 
     feedback_response["overall_score"] = holistic_result.score
     feedback_response["overall_feedback"] = holistic_result.feedback
 
-    api_model = api_model_crud.get_api_model_by_name_and_provider(
+    api_model = await api_model_crud.get_api_model_by_name_and_provider(
         db, request.api_model_name, request.model_provider_name
     )
-    prompt = prompt_crud.get_prompt_by_content(db, request.prompt)
+    prompt = await prompt_crud.get_prompt_by_content(db, request.prompt)
     feedback_create = feedback_schema.FeedbackCreate(
         user_id=user_id,
         prompt_id=prompt.id,
@@ -159,8 +164,8 @@ def generate_feedback(
         created_at=datetime.now(timezone.utc),
     )
 
-    feedback_crud.create_feedback(db, feedback_create)
-    user_api_key_crud.update_last_used(db, db_api_key.id)
+    await feedback_crud.create_feedback(db, feedback_create)
+    await user_api_key_crud.update_last_used(db, db_api_key.id)
 
 
 def get_vlm_client(
@@ -178,26 +183,28 @@ def get_vlm_client(
     return cls(model=model_name, api_key=decrypted_api_key)
 
 
-def generate_feedback_for_handwriting(
-    db: Session,
+async def generate_feedback_for_handwriting(
+    db: AsyncSession,
     user_id: int,
     essay_id: int,
     request: feedback_schema.FeedbackCreateRequest,
 ) -> None:
-    essay = essay_crud.get_essay_by_id(db, essay_id)
+    essay = await essay_crud.get_essay_by_id(db, essay_id)
     if not essay.image_path:
         raise HTTPException(status_code=400, detail="No image found for this essay")
 
-    image_bytes = Path(essay.image_path).read_bytes()
+    image_bytes = await asyncio.to_thread(Path(essay.image_path).read_bytes)
     image_b64 = base64.b64encode(image_bytes).decode("utf-8")
 
-    db_provider = ai_provider_crud.get_provider_by_name(db, request.model_provider_name)
+    db_provider = await ai_provider_crud.get_provider_by_name(
+        db, request.model_provider_name
+    )
     if db_provider is None:
         raise HTTPException(
             status_code=404,
             detail=f"Unknown provider: {request.model_provider_name}",
         )
-    db_api_key = user_api_key_crud.get_user_api_key(db, user_id, db_provider.id)
+    db_api_key = await user_api_key_crud.get_user_api_key(db, user_id, db_provider.id)
     if db_api_key is None:
         raise HTTPException(
             status_code=404,
@@ -220,8 +227,11 @@ def generate_feedback_for_handwriting(
             },
         ]
     )
-    extracted_text = vlm.invoke([ocr_message]).content
+    response = await vlm.ainvoke([ocr_message])
+    extracted_text = response.content
 
-    essay_crud.update_ocr_text(db, essay_id, extracted_text)
+    await essay_crud.update_ocr_text(db, essay_id, extracted_text)
 
-    generate_feedback(db, user_id, essay_id, request, override_content=extracted_text)
+    await generate_feedback(
+        db, user_id, essay_id, request, override_content=extracted_text
+    )

--- a/backend/app/tests/api/routes/test_ielts.py
+++ b/backend/app/tests/api/routes/test_ielts.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -84,16 +84,20 @@ def test_get_llm_client_returns_structured_output(mock_decrypt):
 
 @patch(
     "app.services.feedback_service.ai_provider_crud.get_provider_by_name",
+    new_callable=AsyncMock,
     return_value=None,
 )
 @patch(
     "app.services.feedback_service.rubric_criterion_crud.get_unique_criterion_names_by_rubric",
+    new_callable=AsyncMock,
     return_value=["Task Response"],
 )
 @patch(
-    "app.services.feedback_service.essay_crud.get_essay_by_id", return_value=MagicMock()
+    "app.services.feedback_service.essay_crud.get_essay_by_id",
+    new_callable=AsyncMock,
+    return_value=MagicMock(),
 )
-def test_generate_feedback_unknown_provider_raises_404(
+async def test_generate_feedback_unknown_provider_raises_404(
     mock_essay, mock_criteria, mock_provider
 ):
     """generate_feedback should raise HTTP 404 when provider is not found."""
@@ -102,7 +106,7 @@ def test_generate_feedback_unknown_provider_raises_404(
     request.model_provider_name = "UnknownProvider"
 
     with pytest.raises(HTTPException) as exc_info:
-        generate_feedback(db, user_id=1, essay_id=1, request=request)
+        await generate_feedback(db, user_id=1, essay_id=1, request=request)
 
     assert exc_info.value.status_code == 404
     assert "UnknownProvider" in exc_info.value.detail

--- a/backend/app/tests/api/routes/test_users.py
+++ b/backend/app/tests/api/routes/test_users.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from jose import jwt
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.utils import user_utils
 from app.core.config import settings
@@ -13,32 +13,32 @@ from app.schemas import user_schema
 from app.tests.utils.utils import random_email, random_lower_string
 
 
-def test_create_user_by_normal_user(
-    client: TestClient, normal_user_token_headers: dict[str, str], db: Session
+async def test_create_user_by_normal_user(
+    client: AsyncClient, normal_user_token_headers: dict[str, str], db: AsyncSession
 ) -> None:
     username = random_email()
     password = random_lower_string()
     data = {"email": username, "password": password}
-    r = client.post(
+    r = await client.post(
         f"{settings.API_V1_STR}/user/create",
         headers=normal_user_token_headers,
         json=data,
     )
     assert r.status_code == 204
-    created_user = user_crud.get_user_by_email(db=db, email=username)
+    created_user = await user_crud.get_user_by_email(db=db, email=username)
     assert created_user.email == username
     assert verify_password(password, created_user.password)
 
 
-def test_create_user_existing_username(
-    client: TestClient, normal_user_token_headers: dict[str, str], db: Session
+async def test_create_user_existing_username(
+    client: AsyncClient, normal_user_token_headers: dict[str, str], db: AsyncSession
 ) -> None:
     username = random_email()
     password = random_lower_string()
     user_in = user_schema.UserCreate(email=username, password=password)
-    user_crud.create_user(db=db, user_create=user_in)
+    await user_crud.create_user(db=db, user_create=user_in)
     data = {"email": username, "password": password}
-    r = client.post(
+    r = await client.post(
         f"{settings.API_V1_STR}/user/create",
         headers=normal_user_token_headers,
         json=data,
@@ -46,41 +46,43 @@ def test_create_user_existing_username(
     assert r.status_code == 409
 
 
-def test_login_access_token(client: TestClient, db: Session) -> None:
+async def test_login_access_token(client: AsyncClient, db: AsyncSession) -> None:
     username = random_email()
     password = random_lower_string()
     user_in = user_schema.UserCreate(email=username, password=password)
-    user_crud.create_user(db=db, user_create=user_in)
+    await user_crud.create_user(db=db, user_create=user_in)
 
     login_data = {
         "username": username,
         "password": password,
     }
-    r = client.post(f"{settings.API_V1_STR}/user/login", data=login_data)
+    r = await client.post(f"{settings.API_V1_STR}/user/login", data=login_data)
 
     assert 200 <= r.status_code < 300
-    existing_user = user_crud.get_user_by_email(db=db, email=username)
+    existing_user = await user_crud.get_user_by_email(db=db, email=username)
     assert existing_user
 
 
-def test_login_access_token_non_existing_user(client: TestClient, db: Session) -> None:
+async def test_login_access_token_non_existing_user(
+    client: AsyncClient, db: AsyncSession
+) -> None:
     username = random_email()
     password = random_lower_string()
 
-    user = user_crud.get_user_by_email(db=db, email=username)
+    user = await user_crud.get_user_by_email(db=db, email=username)
     assert user is None
 
     login_data = {
         "username": username,
         "password": password,
     }
-    r = client.post(f"{settings.API_V1_STR}/user/login", data=login_data)
+    r = await client.post(f"{settings.API_V1_STR}/user/login", data=login_data)
 
     assert r.status_code == 401
 
 
-def test_request_reset_password(
-    client: TestClient, db: Session, normal_user_token_headers: dict[str, str]
+async def test_request_reset_password(
+    client: AsyncClient, db: AsyncSession, normal_user_token_headers: dict[str, str]
 ) -> None:
     with (
         patch("app.core.config.settings.SMTP_HOST", "smtp.example.com"),
@@ -89,15 +91,15 @@ def test_request_reset_password(
         username = random_email()
         password = random_lower_string()
         user_in = user_schema.UserCreate(email=username, password=password)
-        user_crud.create_user(db=db, user_create=user_in)
-        user = user_crud.get_user_by_email(db=db, email=username)
+        await user_crud.create_user(db=db, user_create=user_in)
+        user = await user_crud.get_user_by_email(db=db, email=username)
         assert user is not None
 
         data = {
             "email": user.email,
         }
 
-        r = client.post(
+        r = await client.post(
             f"{settings.API_V1_STR}/user/password",
             headers=normal_user_token_headers,
             json=data,
@@ -105,15 +107,15 @@ def test_request_reset_password(
         assert r.status_code == 204
 
 
-def test_request_reset_password_non_existing_user(
-    client: TestClient, db: Session, normal_user_token_headers: dict[str, str]
+async def test_request_reset_password_non_existing_user(
+    client: AsyncClient, db: AsyncSession, normal_user_token_headers: dict[str, str]
 ) -> None:
     username = random_email()
-    user = user_crud.get_user_by_email(db=db, email=username)
+    user = await user_crud.get_user_by_email(db=db, email=username)
     assert user is None
 
     data = {"email": username}
-    r = client.post(
+    r = await client.post(
         f"{settings.API_V1_STR}/user/password",
         headers=normal_user_token_headers,
         json=data,
@@ -121,32 +123,32 @@ def test_request_reset_password_non_existing_user(
     assert r.status_code == 404
 
 
-def test_reset_password(
-    client: TestClient, db: Session, normal_user_token_headers: dict[str, str]
+async def test_reset_password(
+    client: AsyncClient, db: AsyncSession, normal_user_token_headers: dict[str, str]
 ) -> None:
     username = random_email()
     password = random_lower_string()
     user_in = user_schema.UserCreate(email=username, password=password)
-    user_crud.create_user(db=db, user_create=user_in)
-    user = user_crud.get_user_by_email(db=db, email=username)
+    await user_crud.create_user(db=db, user_create=user_in)
+    user = await user_crud.get_user_by_email(db=db, email=username)
     assert user is not None
 
     token = user_utils.generate_password_reset_token(email=user.email)
     data = {"new_password": "changethis", "token": token}
-    r = client.post(
-        f"{settings.API_V1_STR}/user/reset-password/",
+    r = await client.post(
+        f"{settings.API_V1_STR}/user/reset-password",
         headers=normal_user_token_headers,
         json=data,
     )
     assert r.status_code == 200
 
 
-def test_reset_password_invalid_token(
-    client: TestClient, normal_user_token_headers: dict[str, str]
+async def test_reset_password_invalid_token(
+    client: AsyncClient, normal_user_token_headers: dict[str, str]
 ) -> None:
     data = {"new_password": "changethis", "token": "invalid"}
-    r = client.post(
-        f"{settings.API_V1_STR}/user/reset-password/",
+    r = await client.post(
+        f"{settings.API_V1_STR}/user/reset-password",
         headers=normal_user_token_headers,
         json=data,
     )
@@ -157,8 +159,8 @@ def test_reset_password_invalid_token(
     assert response["detail"] == "Invalid token"
 
 
-def test_reset_password_expired_token(
-    client: TestClient, normal_user_token_headers: dict[str, str]
+async def test_reset_password_expired_token(
+    client: AsyncClient, normal_user_token_headers: dict[str, str]
 ) -> None:
     username = random_email()
     invalid_hours = -1
@@ -173,8 +175,8 @@ def test_reset_password_expired_token(
     )
 
     data = {"new_password": "changethis", "token": expired_token}
-    r = client.post(
-        f"{settings.API_V1_STR}/user/reset-password/",
+    r = await client.post(
+        f"{settings.API_V1_STR}/user/reset-password",
         headers=normal_user_token_headers,
         json=data,
     )
@@ -185,17 +187,17 @@ def test_reset_password_expired_token(
     assert response["detail"] == "Invalid token"
 
 
-def test_reset_password_non_existing_user(
-    client: TestClient, db: Session, normal_user_token_headers: dict[str, str]
+async def test_reset_password_non_existing_user(
+    client: AsyncClient, db: AsyncSession, normal_user_token_headers: dict[str, str]
 ) -> None:
     username = random_email()
-    user = user_crud.get_user_by_email(db, email=username)
+    user = await user_crud.get_user_by_email(db, email=username)
     assert user is None
     non_existing_user_token = user_utils.generate_password_reset_token(email=username)
 
     data = {"new_password": "changethis", "token": non_existing_user_token}
-    r = client.post(
-        f"{settings.API_V1_STR}/user/reset-password/",
+    r = await client.post(
+        f"{settings.API_V1_STR}/user/reset-password",
         headers=normal_user_token_headers,
         json=data,
     )

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -1,11 +1,11 @@
-from collections.abc import Generator
+from collections.abc import AsyncGenerator
 
-import pytest
-from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session, sessionmaker
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from app.api.deps import get_db
 from app.core.config import settings
-from app.core.db import engine
 from app.crud import user_crud
 from app.main import app
 from app.models import User
@@ -18,18 +18,16 @@ from app.crud import user_api_key_crud
 
 ALLOWED_TEST_DB_NAMES = ["test"]  # .env variable: TEST_POSTGRES_DB
 
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+test_async_engine = create_async_engine(
+    str(settings.ASYNC_SQLALCHEMY_DATABASE_URI), echo=False
+)
+TestAsyncSessionLocal = async_sessionmaker(
+    test_async_engine, class_=AsyncSession, expire_on_commit=False
+)
 
 
-@pytest.fixture(scope="session")
-def _guard_test_database() -> None:
-    """
-    Block the test session if not connected to a test database.
-    Raise RuntimeError if the connected database is not a known test database.
-
-    Call this before any destructive DB operation in tests to prevent
-    accidental data loss in development or production databases.
-    """
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def _guard_test_database() -> None:
     if settings.POSTGRES_DB not in ALLOWED_TEST_DB_NAMES:
         raise RuntimeError(
             f"Refusing to run tests: connected to database "
@@ -37,83 +35,91 @@ def _guard_test_database() -> None:
         )
 
 
-@pytest.fixture(scope="session", autouse=True)
-def db(_guard_test_database) -> Generator[Session, None, None]:
-    session = SessionLocal()
-    try:
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def db(
+    _guard_test_database,
+) -> AsyncGenerator[AsyncSession, None]:
+    async with TestAsyncSessionLocal() as session:
         yield session
-    finally:
-        session.close()
 
 
-@pytest.fixture()
-def cleanup_api_keys(db: Session, superuser):
+@pytest_asyncio.fixture(loop_scope="session")
+async def cleanup_api_keys(db: AsyncSession, superuser):
     """Delete all UserAPIKey rows for the superuser before and after each test."""
-    keys = user_api_key_crud.get_user_api_key_list(db, superuser.id)
+    keys = await user_api_key_crud.get_user_api_key_list(db, superuser.id)
     for key in keys:
-        user_api_key_crud.delete_api_key(db, key.id)
+        await user_api_key_crud.delete_api_key(db, key.id)
     yield
-    keys = user_api_key_crud.get_user_api_key_list(db, superuser.id)
+    keys = await user_api_key_crud.get_user_api_key_list(db, superuser.id)
     for key in keys:
-        user_api_key_crud.delete_api_key(db, key.id)
+        await user_api_key_crud.delete_api_key(db, key.id)
 
 
-@pytest.fixture()
-def openai_provider(db: Session):
+@pytest_asyncio.fixture(loop_scope="session")
+async def openai_provider(db: AsyncSession):
     """Ensure OpenAI provider exists and return it."""
-    provider = ai_provider_crud.get_provider_by_name(db, "OpenAI")
+    provider = await ai_provider_crud.get_provider_by_name(db, "OpenAI")
     if not provider:
-        provider = ai_provider_crud.create_provider(
+        provider = await ai_provider_crud.create_provider(
             db, ai_provider_schema.AIProviderCreate(name="OpenAI")
         )
     return provider
 
 
-@pytest.fixture()
-def anthropic_provider(db: Session):
+@pytest_asyncio.fixture(loop_scope="session")
+async def anthropic_provider(db: AsyncSession):
     """Ensure Anthropic provider exists and return it."""
-    provider = ai_provider_crud.get_provider_by_name(db, "Anthropic")
+    provider = await ai_provider_crud.get_provider_by_name(db, "Anthropic")
     if not provider:
-        provider = ai_provider_crud.create_provider(
+        provider = await ai_provider_crud.create_provider(
             db, ai_provider_schema.AIProviderCreate(name="Anthropic")
         )
     return provider
 
 
-@pytest.fixture(scope="module")
-def client() -> Generator[TestClient, None, None]:
-    with TestClient(app) as c:
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def client(db: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
+    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
         yield c
+    app.dependency_overrides.clear()
 
 
-@pytest.fixture(scope="module")
-def normal_user_token_headers(client: TestClient, db: Session) -> dict[str, str]:
-    return authentication_token_from_email(
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def normal_user_token_headers(
+    client: AsyncClient, db: AsyncSession
+) -> dict[str, str]:
+    return await authentication_token_from_email(
         client=client, email=settings.EMAIL_TEST_USER, db=db
     )
 
 
-@pytest.fixture(scope="module")
-def test_user(db: Session) -> User:
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def test_user(db: AsyncSession) -> User:
     """Fixture to create a test user."""
     email = random_email()
     password = random_lower_string()
     user_in = user_schema.UserCreate(email=email, password=password)
-    user_crud.create_user(db=db, user_create=user_in)
-    test_user = user_crud.get_user_by_email(db=db, email=email)
+    await user_crud.create_user(db=db, user_create=user_in)
+    test_user = await user_crud.get_user_by_email(db=db, email=email)
     return test_user
 
 
-@pytest.fixture(scope="module")
-def superuser(db: Session) -> User:
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def superuser(db: AsyncSession) -> User:
     """Ensure the superuser exists and return it."""
-    user = user_crud.get_user_by_email(db, settings.FIRST_SUPERUSER)
+    user = await user_crud.get_user_by_email(db, settings.FIRST_SUPERUSER)
     if not user:
         user_create = user_schema.UserCreate(
             email=settings.FIRST_SUPERUSER,
             is_superuser=True,
             password=settings.FIRST_SUPERUSER_PASSWORD,
         )
-        user_crud.create_user(db, user_create)
-        user = user_crud.get_user_by_email(db, settings.FIRST_SUPERUSER)
+        await user_crud.create_user(db, user_create)
+        user = await user_crud.get_user_by_email(db, settings.FIRST_SUPERUSER)
     return user

--- a/backend/app/tests/core/test_db.py
+++ b/backend/app/tests/core/test_db.py
@@ -1,23 +1,23 @@
 import os
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from app.core.db import store_default_api_key
 from app.core.security import decrypt_api_key
 from app.crud import user_api_key_crud
 
 
-def test_store_both_api_keys(
+async def test_store_both_api_keys(
     db, superuser, openai_provider, anthropic_provider, cleanup_api_keys
 ):
     """Both OPENAI_API_KEY and ANTHROPIC_API_KEY set → both keys stored."""
     env = {"OPENAI_API_KEY": "sk-openai-test", "ANTHROPIC_API_KEY": "sk-ant-test"}
     with patch.dict(os.environ, env, clear=False):
-        store_default_api_key(db)
+        await store_default_api_key(db)
 
-    openai_key = user_api_key_crud.get_user_api_key(
+    openai_key = await user_api_key_crud.get_user_api_key(
         db, superuser.id, provider_id=openai_provider.id
     )
-    anthropic_key = user_api_key_crud.get_user_api_key(
+    anthropic_key = await user_api_key_crud.get_user_api_key(
         db, superuser.id, provider_id=anthropic_provider.id
     )
 
@@ -28,7 +28,7 @@ def test_store_both_api_keys(
     assert decrypt_api_key(anthropic_key.api_key) == "sk-ant-test"
 
 
-def test_store_only_openai_key(
+async def test_store_only_openai_key(
     db, superuser, openai_provider, anthropic_provider, cleanup_api_keys
 ):
     """Only OPENAI_API_KEY set → only OpenAI key stored."""
@@ -36,12 +36,12 @@ def test_store_only_openai_key(
     with patch.dict(os.environ, env, clear=False):
         # Remove ANTHROPIC_API_KEY if it happens to exist
         os.environ.pop("ANTHROPIC_API_KEY", None)
-        store_default_api_key(db)
+        await store_default_api_key(db)
 
-    openai_key = user_api_key_crud.get_user_api_key(
+    openai_key = await user_api_key_crud.get_user_api_key(
         db, superuser.id, provider_id=openai_provider.id
     )
-    anthropic_key = user_api_key_crud.get_user_api_key(
+    anthropic_key = await user_api_key_crud.get_user_api_key(
         db, superuser.id, provider_id=anthropic_provider.id
     )
 
@@ -50,19 +50,19 @@ def test_store_only_openai_key(
     assert anthropic_key is None
 
 
-def test_store_only_anthropic_key(
+async def test_store_only_anthropic_key(
     db, superuser, openai_provider, anthropic_provider, cleanup_api_keys
 ):
     """Only ANTHROPIC_API_KEY set → only Anthropic key stored."""
     env = {"ANTHROPIC_API_KEY": "sk-ant-only"}
     with patch.dict(os.environ, env, clear=False):
         os.environ.pop("OPENAI_API_KEY", None)
-        store_default_api_key(db)
+        await store_default_api_key(db)
 
-    openai_key = user_api_key_crud.get_user_api_key(
+    openai_key = await user_api_key_crud.get_user_api_key(
         db, superuser.id, provider_id=openai_provider.id
     )
-    anthropic_key = user_api_key_crud.get_user_api_key(
+    anthropic_key = await user_api_key_crud.get_user_api_key(
         db, superuser.id, provider_id=anthropic_provider.id
     )
 
@@ -71,19 +71,19 @@ def test_store_only_anthropic_key(
     assert decrypt_api_key(anthropic_key.api_key) == "sk-ant-only"
 
 
-def test_store_no_api_keys(
+async def test_store_no_api_keys(
     db, superuser, openai_provider, anthropic_provider, cleanup_api_keys
 ):
     """Neither env var set → no keys created."""
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("OPENAI_API_KEY", None)
         os.environ.pop("ANTHROPIC_API_KEY", None)
-        store_default_api_key(db)
+        await store_default_api_key(db)
 
-    openai_key = user_api_key_crud.get_user_api_key(
+    openai_key = await user_api_key_crud.get_user_api_key(
         db, superuser.id, provider_id=openai_provider.id
     )
-    anthropic_key = user_api_key_crud.get_user_api_key(
+    anthropic_key = await user_api_key_crud.get_user_api_key(
         db, superuser.id, provider_id=anthropic_provider.id
     )
 
@@ -91,32 +91,32 @@ def test_store_no_api_keys(
     assert anthropic_key is None
 
 
-def test_store_api_key_idempotent(db, superuser, openai_provider, cleanup_api_keys):
+async def test_store_api_key_idempotent(
+    db, superuser, openai_provider, cleanup_api_keys
+):
     """Running twice with the same env → no duplicate key created."""
     env = {"OPENAI_API_KEY": "sk-openai-idem"}
     with patch.dict(os.environ, env, clear=False):
         os.environ.pop("ANTHROPIC_API_KEY", None)
-        store_default_api_key(db)
-        store_default_api_key(db)
+        await store_default_api_key(db)
+        await store_default_api_key(db)
 
-    keys = user_api_key_crud.get_user_api_key_list(db, superuser.id)
+    keys = await user_api_key_crud.get_user_api_key_list(db, superuser.id)
     openai_keys = [k for k in keys if k.provider_id == openai_provider.id]
     assert len(openai_keys) == 1
     assert decrypt_api_key(openai_keys[0].api_key) == "sk-openai-idem"
 
 
-def test_store_api_key_skips_missing_provider(db, superuser, cleanup_api_keys):
+async def test_store_api_key_skips_missing_provider(db, superuser, cleanup_api_keys):
     """Provider not in DB → gracefully skipped, no error."""
-    # Use a provider name that doesn't exist in the DB.
-    # We only need to ensure the env var is set but the provider is missing.
     env = {"OPENAI_API_KEY": "sk-openai-noprov", "ANTHROPIC_API_KEY": "sk-ant-noprov"}
 
-    # Delete providers temporarily by patching get_provider_by_name to return None
     with patch.dict(os.environ, env, clear=False), patch(
-        "app.core.db.ai_provider_crud.get_provider_by_name", return_value=None
+        "app.core.db.ai_provider_crud.get_provider_by_name",
+        new_callable=AsyncMock,
+        return_value=None,
     ):
-        store_default_api_key(db)  # should not raise
+        await store_default_api_key(db)  # should not raise
 
-    # No keys should have been created since providers were "missing"
-    keys = user_api_key_crud.get_user_api_key_list(db, superuser.id)
+    keys = await user_api_key_crud.get_user_api_key_list(db, superuser.id)
     assert len(keys) == 0

--- a/backend/app/tests/crud/test_user.py
+++ b/backend/app/tests/crud/test_user.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import get_password_hash
 from app.crud import user_crud
@@ -6,36 +6,38 @@ from app.schemas import user_schema
 from app.tests.utils.utils import random_email, random_lower_string
 
 
-def test_create_user(db: Session) -> None:
+async def test_create_user(db: AsyncSession) -> None:
     email = random_email()
     password = random_lower_string()
     user_in = user_schema.UserCreate(email=email, password=password)
-    user_crud.create_user(db=db, user_create=user_in)
-    auth_user = user_crud.authenticate(db=db, email=email, password=password)
+    await user_crud.create_user(db=db, user_create=user_in)
+    auth_user = await user_crud.authenticate(db=db, email=email, password=password)
     assert auth_user
     assert auth_user.email == email
 
 
-def test_not_authenticate_user(db: Session) -> None:
+async def test_not_authenticate_user(db: AsyncSession) -> None:
     email = random_email()
     password = random_lower_string()
-    auth_user = user_crud.authenticate(db=db, email=email, password=password)
+    auth_user = await user_crud.authenticate(db=db, email=email, password=password)
     assert auth_user is None
 
 
-def test_update_user(db: Session) -> None:
+async def test_update_user(db: AsyncSession) -> None:
     password = random_lower_string()
     email = random_email()
     user_in = user_schema.UserCreate(email=email, password=password)
-    user_crud.create_user(db=db, user_create=user_in)
-    created_user = user_crud.get_user_by_email(db=db, email=email)
+    await user_crud.create_user(db=db, user_create=user_in)
+    created_user = await user_crud.get_user_by_email(db=db, email=email)
 
     new_password = random_lower_string()
     new_password_hashsed = get_password_hash(new_password)
-    user_crud.update_user_password(
+    await user_crud.update_user_password(
         db=db, user=created_user, new_password=new_password_hashsed
     )
-    updated_user = user_crud.authenticate(db=db, email=email, password=new_password)
+    updated_user = await user_crud.authenticate(
+        db=db, email=email, password=new_password
+    )
 
     assert updated_user
     assert created_user.email == updated_user.email

--- a/backend/app/tests/utils/user.py
+++ b/backend/app/tests/utils/user.py
@@ -1,5 +1,5 @@
-from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core import security
 from app.core.config import settings
@@ -8,20 +8,20 @@ from app.schemas import user_schema
 from app.tests.utils.utils import random_lower_string
 
 
-def user_authentication_headers(
-    *, client: TestClient, email: str, password: str
+async def user_authentication_headers(
+    *, client: AsyncClient, email: str, password: str
 ) -> dict[str, str]:
     data = {"username": email, "password": password}
 
-    r = client.post(f"{settings.API_V1_STR}/user/login", data=data)
+    r = await client.post(f"{settings.API_V1_STR}/user/login", data=data)
     response = r.json()
     auth_token = response["access_token"]
     headers = {"Authorization": f"Bearer {auth_token}"}
     return headers
 
 
-def authentication_token_from_email(
-    *, client: TestClient, email: str, db: Session
+async def authentication_token_from_email(
+    *, client: AsyncClient, email: str, db: AsyncSession
 ) -> dict[str, str]:
     """
     Return a valid token for the user with given email.
@@ -29,17 +29,19 @@ def authentication_token_from_email(
     If the user doesn't exist it is created first.
     """
     password = random_lower_string()
-    user = user_crud.get_user_by_email(db=db, email=email)
+    user = await user_crud.get_user_by_email(db=db, email=email)
     if not user:
         user_in_create = user_schema.UserCreate(email=email, password=password)
-        user_crud.create_user(db=db, user_create=user_in_create)
-        user = user_crud.get_user_by_email(db=db, email=email)
+        await user_crud.create_user(db=db, user_create=user_in_create)
+        user = await user_crud.get_user_by_email(db=db, email=email)
     else:
         if not user.id:
             raise Exception("User id not set")
         hashed_password = security.get_password_hash(password=password)
-        user = user_crud.update_user_password(
+        await user_crud.update_user_password(
             db=db, user=user, new_password=hashed_password
         )
 
-    return user_authentication_headers(client=client, email=email, password=password)
+    return await user_authentication_headers(
+        client=client, email=email, password=password
+    )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -33,8 +33,13 @@ dev = [
     "coverage>=7.7.1,<8.0.0",
     "ruff>=0.11.2,<0.12.0",
     "pytest>=8.3.5,<9.0.0",
+    "pytest-asyncio>=0.25,<0.26",
+    "httpx>=0.28,<0.29",
     "debugpy>=1.8.20,<2.0.0",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary
- Convert entire backend from synchronous to async SQLAlchemy (`AsyncSession`, `create_async_engine`, `psycopg_async`)
- Migrate all 11 CRUD files to `async def` with `select()` + `await` pattern, adding `selectinload()` for 4 lazy-loaded relationships
- Convert LLM calls from `.invoke()` to `.ainvoke()` for true async concurrency
- Convert startup functions (`init_db`, `store_default_*`) and `initial_data.py` to async
- Migrate test infrastructure from `TestClient` to `httpx.AsyncClient` with `pytest-asyncio` fixtures

## Test plan
- [x] All 24 tests pass in Docker (`docker compose exec backend uv run pytest app/tests/ -v`)
- [x] Backend starts successfully with async initial data seeding
- [ ] Manual smoke test via Swagger `/docs`
- [ ] Verify LLM feedback generation works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)