### PR TITLE
test: add comprehensive backend and frontend test suites

### DIFF
--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -1,0 +1,49 @@
+name: Test Frontend
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    paths:
+      - 'frontend/**'
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test
+
+  alls-green:
+    if: always()
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/backend/app/tests/agents/test_aggregator.py
+++ b/backend/app/tests/agents/test_aggregator.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from app.agents.aggregator import Aggregator, _round_half_band
+from app.agents.aggregator import Aggregator, _round_score
 from app.agents.schema import (
     AgentConfig,
     AggregationMethod,
@@ -43,13 +43,25 @@ def _make_aggregator_agent() -> AgentConfig:
     )
 
 
-def test_round_half_band():
-    assert _round_half_band(6.25) == 6.5
-    assert _round_half_band(6.75) == 7.0
-    assert _round_half_band(6.0) == 6.0
-    assert _round_half_band(6.5) == 6.5
-    assert _round_half_band(6.1) == 6.0
-    assert _round_half_band(6.9) == 7.0
+def test_round_score_half_band():
+    assert _round_score(6.25, "half_band") == 6.5
+    assert _round_score(6.75, "half_band") == 7.0
+    assert _round_score(6.0, "half_band") == 6.0
+    assert _round_score(6.5, "half_band") == 6.5
+    assert _round_score(6.1, "half_band") == 6.0
+    assert _round_score(6.9, "half_band") == 7.0
+
+
+def test_round_score_integer():
+    assert _round_score(6.25, "integer") == 6
+    assert _round_score(6.75, "integer") == 7
+    assert _round_score(6.5, "integer") == 6  # Python banker's rounding
+    assert _round_score(7.5, "integer") == 8
+
+
+def test_round_score_none():
+    assert _round_score(6.25, "none") == 6.25
+    assert _round_score(6.789, "none") == 6.789
 
 
 def test_weighted_average_equal_weights():

--- a/backend/app/tests/api/routes/test_ielts_routes.py
+++ b/backend/app/tests/api/routes/test_ielts_routes.py
@@ -1,0 +1,55 @@
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models import Prompt
+
+
+async def test_get_prompts(client: AsyncClient, db: AsyncSession) -> None:
+    r = await client.get(f"{settings.API_V1_STR}/ielts/prompts")
+
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+
+
+async def test_submit_and_list_essays(
+    client: AsyncClient,
+    db: AsyncSession,
+    normal_user_token_headers: dict[str, str],
+    test_prompt: Prompt,
+) -> None:
+    submit_data = {
+        "prompt_id": test_prompt.id,
+        "content": "Route test essay: Technology changes education fundamentally.",
+    }
+    r_submit = await client.post(
+        f"{settings.API_V1_STR}/ielts/essays",
+        headers=normal_user_token_headers,
+        json=submit_data,
+    )
+    assert r_submit.status_code == 200
+    assert "id" in r_submit.json()
+    assert "content" in r_submit.json()
+
+    r_list = await client.get(
+        f"{settings.API_V1_STR}/ielts/essays",
+        headers=normal_user_token_headers,
+        params={"prompt_id": test_prompt.id},
+    )
+    assert r_list.status_code == 200
+    assert len(r_list.json()) >= 1
+
+
+async def test_get_feedbacks_empty(
+    client: AsyncClient,
+    db: AsyncSession,
+    normal_user_token_headers: dict[str, str],
+    test_prompt: Prompt,
+) -> None:
+    r = await client.get(
+        f"{settings.API_V1_STR}/ielts/feedbacks",
+        headers=normal_user_token_headers,
+        params={"prompt_id": test_prompt.id, "essay_id": 999999},
+    )
+    assert r.status_code == 200
+    assert r.json() == []

--- a/backend/app/tests/api/routes/test_ksat.py
+++ b/backend/app/tests/api/routes/test_ksat.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timezone
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.crud import prompt_crud
+from app.schemas import prompt_schema
+
+
+async def test_list_exams(client: AsyncClient, db: AsyncSession) -> None:
+    r = await client.get(f"{settings.API_V1_STR}/ksat/exams")
+
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+    # Verify exam_type field is present in response if exams exist
+    if r.json():
+        assert "exam_type" in r.json()[0]
+
+
+async def test_get_exam_not_found(client: AsyncClient, db: AsyncSession) -> None:
+    r = await client.get(f"{settings.API_V1_STR}/ksat/exams/999999")
+
+    assert r.status_code == 404
+    assert r.json()["detail"] == "Exam not found"
+
+
+async def test_submit_and_list_ksat_essays(
+    client: AsyncClient,
+    db: AsyncSession,
+    normal_user_token_headers: dict[str, str],
+    test_user,
+) -> None:
+    # Create a prompt for this test
+    ksat_prompt = await prompt_crud.create_prompt(
+        db,
+        prompt_schema.PromptCreate(
+            content="KSAT route test prompt.",
+            created_by=test_user.id,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        ),
+    )
+
+    # Submit essay
+    submit_data = {
+        "prompt_id": ksat_prompt.id,
+        "content": "KSAT test essay content for route validation.",
+    }
+    r_submit = await client.post(
+        f"{settings.API_V1_STR}/ksat/essays",
+        headers=normal_user_token_headers,
+        json=submit_data,
+    )
+    assert r_submit.status_code == 200
+    assert "id" in r_submit.json()
+
+    # List essays
+    r_list = await client.get(
+        f"{settings.API_V1_STR}/ksat/essays",
+        headers=normal_user_token_headers,
+        params={"prompt_id": ksat_prompt.id},
+    )
+    assert r_list.status_code == 200
+    assert len(r_list.json()) >= 1

--- a/backend/app/tests/api/routes/test_shared.py
+++ b/backend/app/tests/api/routes/test_shared.py
@@ -1,0 +1,86 @@
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+
+
+async def test_read_bots(client: AsyncClient, db: AsyncSession) -> None:
+    r = await client.get(f"{settings.API_V1_STR}/shared/bots")
+
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+
+
+async def test_read_providers(client: AsyncClient, db: AsyncSession) -> None:
+    r = await client.get(f"{settings.API_V1_STR}/shared/providers")
+
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+
+
+async def test_create_and_list_api_keys(
+    client: AsyncClient,
+    db: AsyncSession,
+    normal_user_token_headers: dict[str, str],
+    openai_provider,
+) -> None:
+    create_data = {
+        "provider_name": "OpenAI",
+        "name": "route-test-key",
+        "api_key": "sk-route-test-123",
+    }
+    r_create = await client.post(
+        f"{settings.API_V1_STR}/shared/api_keys",
+        headers=normal_user_token_headers,
+        json=create_data,
+    )
+    assert r_create.status_code == 204
+
+    r_list = await client.get(
+        f"{settings.API_V1_STR}/shared/api_keys",
+        headers=normal_user_token_headers,
+    )
+    assert r_list.status_code == 200
+    keys = r_list.json()
+    assert isinstance(keys, list)
+    assert len(keys) >= 1
+    assert any(k["name"] == "route-test-key" for k in keys)
+
+
+async def test_delete_api_key(
+    client: AsyncClient,
+    db: AsyncSession,
+    normal_user_token_headers: dict[str, str],
+    openai_provider,
+) -> None:
+    # Create a key to delete
+    create_data = {
+        "provider_name": "OpenAI",
+        "name": "delete-route-key",
+        "api_key": "sk-delete-test-456",
+    }
+    await client.post(
+        f"{settings.API_V1_STR}/shared/api_keys",
+        headers=normal_user_token_headers,
+        json=create_data,
+    )
+
+    # Get the id
+    r_list = await client.get(
+        f"{settings.API_V1_STR}/shared/api_keys",
+        headers=normal_user_token_headers,
+    )
+    key_id = next(k["id"] for k in r_list.json() if k["name"] == "delete-route-key")
+
+    # Delete
+    r_delete = await client.delete(
+        f"{settings.API_V1_STR}/shared/api_keys/{key_id}",
+    )
+    assert r_delete.status_code == 200
+
+    # Verify deleted
+    r_list_after = await client.get(
+        f"{settings.API_V1_STR}/shared/api_keys",
+        headers=normal_user_token_headers,
+    )
+    assert all(k["id"] != key_id for k in r_list_after.json())

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -8,12 +8,12 @@ from app.api.deps import get_db
 from app.core.config import settings
 from app.crud import user_crud
 from app.main import app
-from app.models import User
+from app.models import Bot, Prompt, User
 from app.schemas import user_schema
 from app.tests.utils.user import authentication_token_from_email
 from app.tests.utils.utils import random_email, random_lower_string
-from app.crud import ai_provider_crud
-from app.schemas import ai_provider_schema
+from app.crud import ai_provider_crud, bot_crud, prompt_crud
+from app.schemas import ai_provider_schema, bot_schema, prompt_schema
 from app.crud import user_api_key_crud
 
 ALLOWED_TEST_DB_NAMES = ["test"]  # .env variable: TEST_POSTGRES_DB
@@ -75,6 +75,31 @@ async def anthropic_provider(db: AsyncSession):
             db, ai_provider_schema.AIProviderCreate(name="Anthropic")
         )
     return provider
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def test_prompt(db: AsyncSession, test_user) -> Prompt:
+    """Create a reusable prompt for essay/feedback tests."""
+    from datetime import datetime, timezone
+
+    pc = prompt_schema.PromptCreate(
+        content="Describe the impact of technology on education.",
+        created_by=test_user.id,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    return await prompt_crud.create_prompt(db, pc)
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def test_bot(db: AsyncSession) -> Bot:
+    """Ensure a test bot exists and return it."""
+    bot = await bot_crud.get_bot_by_name(db, "TestBot")
+    if not bot:
+        bot = await bot_crud.create_bot(
+            db, bot_schema.BotCreate(name="TestBot", version="1.0")
+        )
+    return bot
 
 
 @pytest_asyncio.fixture(scope="module", loop_scope="session")

--- a/backend/app/tests/crud/test_ai_provider.py
+++ b/backend/app/tests/crud/test_ai_provider.py
@@ -1,0 +1,27 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud import ai_provider_crud
+from app.schemas import ai_provider_schema
+from app.tests.utils.utils import random_lower_string
+
+
+async def test_create_provider_and_get_by_name(db: AsyncSession) -> None:
+    name = f"Provider_{random_lower_string()[:8]}"
+    provider_create = ai_provider_schema.AIProviderCreate(name=name)
+    created = await ai_provider_crud.create_provider(db, provider_create)
+
+    assert created.id is not None
+    assert created.name == name
+    assert created.deprecated is False
+
+    fetched = await ai_provider_crud.get_provider_by_name(db, name)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+async def test_get_providers(db: AsyncSession) -> None:
+    result = await ai_provider_crud.get_providers(db)
+
+    assert isinstance(result, list)
+    assert len(result) >= 1

--- a/backend/app/tests/crud/test_api_model.py
+++ b/backend/app/tests/crud/test_api_model.py
@@ -1,0 +1,39 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud import api_model_crud, bot_crud
+from app.schemas import api_model_schema, bot_schema
+from app.tests.utils.utils import random_lower_string
+
+
+async def test_create_api_model_and_get_by_alias(
+    db: AsyncSession, openai_provider
+) -> None:
+    # create_api_model internally calls get_bot_by_name(db, alias),
+    # so a bot with name == alias must exist first
+    alias = f"ApiBot_{random_lower_string()[:8]}"
+    bot = await bot_crud.create_bot(db, bot_schema.BotCreate(name=alias, version="1.0"))
+
+    model_create = api_model_schema.APIModelCreate(
+        api_model_name=f"gpt-4o-{random_lower_string()[:6]}",
+        alias=alias,
+        provider_name="OpenAI",
+    )
+    created = await api_model_crud.create_api_model(db, model_create)
+
+    assert created.id is not None
+    assert created.api_model_name == model_create.api_model_name
+    assert created.alias == alias
+    assert created.bot_id == bot.id
+    assert created.provider_id == openai_provider.id
+
+    fetched = await api_model_crud.get_api_model_by_alias(db, alias)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+async def test_get_api_models_by_provider(db: AsyncSession, openai_provider) -> None:
+    result = await api_model_crud.get_api_models_by_provider(db, "OpenAI")
+
+    assert isinstance(result, list)
+    assert len(result) >= 1

--- a/backend/app/tests/crud/test_bot.py
+++ b/backend/app/tests/crud/test_bot.py
@@ -1,0 +1,29 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud import bot_crud
+from app.schemas import bot_schema
+from app.tests.utils.utils import random_lower_string
+
+
+async def test_create_bot_and_get_by_name(db: AsyncSession) -> None:
+    name = f"Bot_{random_lower_string()[:8]}"
+    bot_create = bot_schema.BotCreate(
+        name=name, version="2.0", description="For testing"
+    )
+    created = await bot_crud.create_bot(db, bot_create)
+
+    assert created.id is not None
+    assert created.name == name
+    assert created.version == "2.0"
+
+    fetched = await bot_crud.get_bot_by_name(db, name)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+async def test_get_bots(db: AsyncSession) -> None:
+    result = await bot_crud.get_bots(db)
+
+    assert isinstance(result, list)
+    assert len(result) >= 1

--- a/backend/app/tests/crud/test_essay.py
+++ b/backend/app/tests/crud/test_essay.py
@@ -1,0 +1,86 @@
+from datetime import datetime, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud import essay_crud, prompt_crud
+from app.models import Prompt, User
+from app.schemas import essay_schema, prompt_schema
+
+
+async def test_create_essay_and_get_by_id(
+    db: AsyncSession, test_user: User, test_prompt: Prompt
+) -> None:
+    essay_create = essay_schema.EssayCreate(
+        user_id=test_user.id,
+        prompt_id=test_prompt.id,
+        content="Technology has transformed the way students learn.",
+        submitted_at=datetime.now(timezone.utc),
+    )
+    created = await essay_crud.create_essay(db, essay_create)
+
+    assert created.id is not None
+    assert created.user_id == test_user.id
+    assert created.prompt_id == test_prompt.id
+    assert created.content == essay_create.content
+
+    fetched = await essay_crud.get_essay_by_id(db, created.id)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+async def test_get_duplicated_essay(
+    db: AsyncSession, test_user: User, test_prompt: Prompt
+) -> None:
+    content = "This is a unique essay for duplication test."
+    essay_create = essay_schema.EssayCreate(
+        user_id=test_user.id,
+        prompt_id=test_prompt.id,
+        content=content,
+        submitted_at=datetime.now(timezone.utc),
+    )
+    original = await essay_crud.create_essay(db, essay_create)
+
+    # Same content with extra whitespace — should still match via normalise_content
+    dup = await essay_crud.get_duplicated_essay(
+        db, test_user.id, test_prompt.id, f"  {content}  "
+    )
+
+    assert dup is not None
+    assert dup.id == original.id
+
+
+async def test_get_essay_list_by_prompt_id(db: AsyncSession, test_user: User) -> None:
+    # Create a dedicated prompt to isolate this test
+    pc = prompt_schema.PromptCreate(
+        content="Prompt for essay list test.",
+        created_by=test_user.id,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    prompt = await prompt_crud.create_prompt(db, pc)
+
+    await essay_crud.create_essay(
+        db,
+        essay_schema.EssayCreate(
+            user_id=test_user.id,
+            prompt_id=prompt.id,
+            content="First essay for list test.",
+            submitted_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        ),
+    )
+    await essay_crud.create_essay(
+        db,
+        essay_schema.EssayCreate(
+            user_id=test_user.id,
+            prompt_id=prompt.id,
+            content="Second essay for list test.",
+            submitted_at=datetime(2025, 6, 1, tzinfo=timezone.utc),
+        ),
+    )
+
+    result = await essay_crud.get_essay_list_by_prompt_id(db, test_user.id, prompt.id)
+
+    assert len(result) >= 2
+    # Verify descending order by submitted_at
+    assert result[0].submitted_at >= result[1].submitted_at

--- a/backend/app/tests/crud/test_feedback.py
+++ b/backend/app/tests/crud/test_feedback.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud import essay_crud, feedback_crud
+from app.models import Bot, Prompt, User
+from app.schemas import essay_schema, feedback_schema
+
+
+async def test_create_feedback(
+    db: AsyncSession, test_user: User, test_prompt: Prompt, test_bot: Bot
+) -> None:
+    essay = await essay_crud.create_essay(
+        db,
+        essay_schema.EssayCreate(
+            user_id=test_user.id,
+            prompt_id=test_prompt.id,
+            content="Essay for feedback creation test.",
+            submitted_at=datetime.now(timezone.utc),
+        ),
+    )
+
+    feedback_content = {
+        "overall_score": 7.0,
+        "overall_feedback": "Good essay with clear arguments.",
+        "feedback_by_criteria": {
+            "Task Response": {"score": 7, "feedback": "Addresses the task well."},
+        },
+    }
+    fb_create = feedback_schema.FeedbackCreate(
+        user_id=test_user.id,
+        prompt_id=test_prompt.id,
+        essay_id=essay.id,
+        bot_id=test_bot.id,
+        content=feedback_content,
+        created_at=datetime.now(timezone.utc),
+    )
+    result = await feedback_crud.create_feedback(db, fb_create)
+
+    assert result.id is not None
+    assert result.user_id == test_user.id
+    assert result.essay_id == essay.id
+    assert result.bot_id == test_bot.id
+    assert result.content == feedback_content
+
+
+async def test_get_feedbacks_by_user_prompt_essay(
+    db: AsyncSession, test_user: User, test_prompt: Prompt, test_bot: Bot
+) -> None:
+    essay = await essay_crud.create_essay(
+        db,
+        essay_schema.EssayCreate(
+            user_id=test_user.id,
+            prompt_id=test_prompt.id,
+            content="Essay for feedback retrieval test.",
+            submitted_at=datetime.now(timezone.utc),
+        ),
+    )
+
+    fb_create = feedback_schema.FeedbackCreate(
+        user_id=test_user.id,
+        prompt_id=test_prompt.id,
+        essay_id=essay.id,
+        bot_id=test_bot.id,
+        content={"overall_score": 6.5, "overall_feedback": "Decent work."},
+        created_at=datetime.now(timezone.utc),
+    )
+    await feedback_crud.create_feedback(db, fb_create)
+
+    result = await feedback_crud.get_feedbacks_by_user_prompt_essay(
+        db, test_user.id, test_prompt.id, essay.id
+    )
+
+    assert len(result) >= 1
+    # Verify bot is eagerly loaded via selectinload
+    assert result[0].bot is not None
+    assert result[0].bot.name == "TestBot"
+    assert result[0].content["overall_score"] == 6.5

--- a/backend/app/tests/crud/test_prompt.py
+++ b/backend/app/tests/crud/test_prompt.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud import prompt_crud
+from app.models import User
+from app.schemas import prompt_schema
+from app.tests.utils.utils import random_lower_string
+
+
+async def test_create_prompt(db: AsyncSession, test_user: User) -> None:
+    content = f"Prompt create test {random_lower_string()[:10]}"
+    prompt_create = prompt_schema.PromptCreate(
+        content=content,
+        created_by=test_user.id,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    result = await prompt_crud.create_prompt(db, prompt_create)
+
+    assert result is not None
+    assert result.id is not None
+    assert result.content == content
+    assert result.created_by == test_user.id
+
+
+async def test_get_prompt_by_id(db: AsyncSession, test_user: User) -> None:
+    content = f"Prompt get_by_id test {random_lower_string()[:10]}"
+    prompt_create = prompt_schema.PromptCreate(
+        content=content,
+        created_by=test_user.id,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    created = await prompt_crud.create_prompt(db, prompt_create)
+
+    fetched = await prompt_crud.get_prompt_by_id(db, created.id)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.content == created.content
+
+
+async def test_get_prompt_by_content(db: AsyncSession, test_user: User) -> None:
+    content = f"Prompt get_by_content test {random_lower_string()[:10]}"
+    prompt_create = prompt_schema.PromptCreate(
+        content=content,
+        created_by=test_user.id,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    created = await prompt_crud.create_prompt(db, prompt_create)
+
+    fetched = await prompt_crud.get_prompt_by_content(db, content)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.content == content

--- a/backend/app/tests/crud/test_user_api_key.py
+++ b/backend/app/tests/crud/test_user_api_key.py
@@ -1,0 +1,64 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud import user_api_key_crud
+from app.schemas import user_api_key_schema
+
+
+async def test_create_and_get_user_api_key(
+    db: AsyncSession, superuser, openai_provider, cleanup_api_keys
+) -> None:
+    key_create = user_api_key_schema.UserAPIKeyCreate(
+        user_id=superuser.id,
+        provider_id=openai_provider.id,
+        name="test-key-1",
+        api_key="sk-test-encrypted-value-123",
+    )
+    created = await user_api_key_crud.create_user_api_key(db, key_create)
+
+    assert created.id is not None
+    assert created.user_id == superuser.id
+    assert created.name == "test-key-1"
+    assert created.is_active is True
+
+    fetched = await user_api_key_crud.get_user_api_key(
+        db, superuser.id, openai_provider.id
+    )
+
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+async def test_get_user_api_key_list(
+    db: AsyncSession, superuser, openai_provider, cleanup_api_keys
+) -> None:
+    key_create = user_api_key_schema.UserAPIKeyCreate(
+        user_id=superuser.id,
+        provider_id=openai_provider.id,
+        name="list-test-key",
+        api_key="sk-test-list-value",
+    )
+    await user_api_key_crud.create_user_api_key(db, key_create)
+
+    result = await user_api_key_crud.get_user_api_key_list(db, superuser.id)
+
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    # Verify provider is eagerly loaded via selectinload
+    assert result[0].provider is not None
+
+
+async def test_delete_api_key(
+    db: AsyncSession, superuser, openai_provider, cleanup_api_keys
+) -> None:
+    key_create = user_api_key_schema.UserAPIKeyCreate(
+        user_id=superuser.id,
+        provider_id=openai_provider.id,
+        name="delete-test-key",
+        api_key="sk-test-delete-value",
+    )
+    created = await user_api_key_crud.create_user_api_key(db, key_create)
+
+    await user_api_key_crud.delete_api_key(db, created.id)
+
+    remaining = await user_api_key_crud.get_user_api_key_list(db, superuser.id)
+    assert all(k.id != created.id for k in remaining)

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,9 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/frontend/e2e/example.spec.js
+++ b/frontend/e2e/example.spec.js
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('app loads successfully', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle(/.+/);
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "svelte-spa-router": "^4.0.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.3.1",
@@ -811,6 +812,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -2308,6 +2325,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,9 +8,13 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "npx playwright test",
+    "test:e2e:ui": "npx playwright test --ui",
+    "test:e2e:report": "npx playwright show-report"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.3.1",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+    // Uncomment to add more browsers:
+    // { name: 'firefox', use: { browserName: 'firefox' } },
+    // { name: 'webkit', use: { browserName: 'webkit' } },
+  ],
+});

--- a/frontend/src/tests/components/DeleteConfirmModal.test.js
+++ b/frontend/src/tests/components/DeleteConfirmModal.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import DeleteConfirmModal from '../../components/DeleteConfirmModal.svelte';
+
+describe('DeleteConfirmModal component', () => {
+  it('renders item name in confirmation message', () => {
+    const { getByText } = render(DeleteConfirmModal, {
+      props: { open: true, itemName: 'My API Key' },
+    });
+    expect(getByText('My API Key')).toBeInTheDocument();
+    expect(getByText(/Are you sure you want to delete/)).toBeInTheDocument();
+  });
+
+  it('calls onConfirm when Yes Delete clicked', async () => {
+    const onConfirm = vi.fn();
+    const { getByText } = render(DeleteConfirmModal, {
+      props: { open: true, itemName: 'Key', onConfirm },
+    });
+    await fireEvent.click(getByText('Yes, Delete'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when Cancel clicked', async () => {
+    const onCancel = vi.fn();
+    const { getByText } = render(DeleteConfirmModal, {
+      props: { open: true, itemName: 'Key', onCancel },
+    });
+    await fireEvent.click(getByText('Cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/tests/components/Dropdown.test.js
+++ b/frontend/src/tests/components/Dropdown.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import DropdownWrapper from './_DropdownWrapper.svelte';
+
+describe('Dropdown component', () => {
+  it('menu hidden initially', () => {
+    const { queryByTestId } = render(DropdownWrapper);
+    expect(queryByTestId('menu-item')).toBeNull();
+  });
+
+  it('menu visible after trigger click', async () => {
+    const { getByTestId, queryByTestId } = render(DropdownWrapper);
+    await fireEvent.click(getByTestId('trigger'));
+    expect(queryByTestId('menu-item')).not.toBeNull();
+  });
+
+  it('menu closes after close function called', async () => {
+    const { getByTestId, queryByTestId } = render(DropdownWrapper);
+    await fireEvent.click(getByTestId('trigger'));
+    expect(queryByTestId('menu-item')).not.toBeNull();
+    await fireEvent.click(getByTestId('menu-item'));
+    expect(queryByTestId('menu-item')).toBeNull();
+  });
+});

--- a/frontend/src/tests/components/EssayWriter.test.js
+++ b/frontend/src/tests/components/EssayWriter.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+
+vi.mock('../../components/HandwritingCanvas.svelte', () => ({
+  default: {},
+}));
+
+import EssayWriter from '../../components/EssayWriter.svelte';
+
+describe('EssayWriter component', () => {
+  it('shows placeholder when no promptContent', () => {
+    const { getByText, container } = render(EssayWriter, {
+      props: { promptContent: '' },
+    });
+    expect(getByText('Please select a prompt from the Prompts tab')).toBeInTheDocument();
+    expect(container.querySelector('textarea')).toBeNull();
+  });
+
+  it('renders textarea when promptContent is set', () => {
+    const { getByText, container } = render(EssayWriter, {
+      props: { promptContent: 'Write about climate change.' },
+    });
+    expect(getByText('Write about climate change.')).toBeInTheDocument();
+    expect(container.querySelector('textarea')).not.toBeNull();
+  });
+
+  it('disables submit button when essayContent is empty', () => {
+    const { getByText } = render(EssayWriter, {
+      props: { promptContent: 'Prompt', essayContent: '' },
+    });
+    expect(getByText('Submit for Feedback').disabled).toBe(true);
+  });
+
+  it('enables submit button when essayContent has text', () => {
+    const { getByText } = render(EssayWriter, {
+      props: { promptContent: 'Prompt', essayContent: 'My essay text' },
+    });
+    expect(getByText('Submit for Feedback').disabled).toBe(false);
+  });
+
+  it('calls onSubmitEssay on submit click', async () => {
+    const onSubmitEssay = vi.fn();
+    const { getByText } = render(EssayWriter, {
+      props: { promptContent: 'Prompt', essayContent: 'My essay', onSubmitEssay },
+    });
+    await fireEvent.click(getByText('Submit for Feedback'));
+    expect(onSubmitEssay).toHaveBeenCalledTimes(1);
+  });
+
+  it('displays word count in text mode', () => {
+    const { getByText } = render(EssayWriter, {
+      props: { promptContent: 'Prompt', wordCount: 42 },
+    });
+    expect(getByText('Word count: 42')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/ExampleAnswer.test.js
+++ b/frontend/src/tests/components/ExampleAnswer.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import ExampleAnswer from '../../components/ExampleAnswer.svelte';
+
+describe('ExampleAnswer component', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn(() => Promise.resolve()) },
+    });
+  });
+
+  it('renders Example Answer heading', () => {
+    const { getByText } = render(ExampleAnswer, {
+      props: { exampleAnswer: 'Sample text' },
+    });
+    expect(getByText('Example Answer')).toBeInTheDocument();
+  });
+
+  it('renders example answer content', () => {
+    const { container } = render(ExampleAnswer, {
+      props: { exampleAnswer: 'This is a sample essay.' },
+    });
+    expect(container.textContent).toContain('This is a sample essay.');
+  });
+
+  it('has a copy button with correct aria-label', () => {
+    const { container } = render(ExampleAnswer, {
+      props: { exampleAnswer: 'Text' },
+    });
+    expect(container.querySelector('[aria-label="Copy to clipboard"]')).not.toBeNull();
+  });
+
+  it('copy button calls clipboard API', async () => {
+    const { container } = render(ExampleAnswer, {
+      props: { exampleAnswer: 'Copy me' },
+    });
+    const btn = container.querySelector('[aria-label="Copy to clipboard"]');
+    await fireEvent.click(btn);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Copy me');
+  });
+});

--- a/frontend/src/tests/components/Modal.test.js
+++ b/frontend/src/tests/components/Modal.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import Modal from '../../components/Modal.svelte';
+
+describe('Modal component', () => {
+  it('renders nothing when open is false', () => {
+    const { container } = render(Modal, { props: { open: false, title: 'Test' } });
+    expect(container.querySelector('.modal')).toBeNull();
+  });
+
+  it('renders modal with title when open is true', () => {
+    const { getByText, container } = render(Modal, {
+      props: { open: true, title: 'My Title' },
+    });
+    expect(container.querySelector('.modal')).not.toBeNull();
+    expect(getByText('My Title')).toBeInTheDocument();
+  });
+
+  it('applies size class based on size prop', () => {
+    const { container: smContainer } = render(Modal, {
+      props: { open: true, title: 'Small', size: 'sm' },
+    });
+    expect(smContainer.querySelector('.modal-sm')).not.toBeNull();
+
+    const { container: lgContainer } = render(Modal, {
+      props: { open: true, title: 'Large', size: 'lg' },
+    });
+    expect(lgContainer.querySelector('.modal-lg')).not.toBeNull();
+
+    // md size should not add modal-sm or modal-lg
+    const { container: mdContainer } = render(Modal, {
+      props: { open: true, title: 'Medium', size: 'md' },
+    });
+    expect(mdContainer.querySelector('.modal-sm')).toBeNull();
+    expect(mdContainer.querySelector('.modal-lg')).toBeNull();
+  });
+
+  it('calls onClose when close button clicked', async () => {
+    const onClose = vi.fn();
+    const { container } = render(Modal, {
+      props: { open: true, title: 'Close Test', onClose },
+    });
+    await fireEvent.click(container.querySelector('.btn-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/tests/components/ModelSelector.test.js
+++ b/frontend/src/tests/components/ModelSelector.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import ModelSelector from '../../components/ModelSelector.svelte';
+
+const providers = [{ name: 'OpenAI' }, { name: 'Anthropic' }];
+const models = [{ alias: 'GPT-4o' }, { alias: 'Claude Sonnet' }];
+
+describe('ModelSelector component', () => {
+  it('renders provider options', () => {
+    const { getByText, container } = render(ModelSelector, {
+      props: { AIModelProviders: providers, feedbackModels: [] },
+    });
+    expect(getByText('OpenAI')).toBeInTheDocument();
+    expect(getByText('Anthropic')).toBeInTheDocument();
+    expect(container.querySelectorAll('select').length).toBe(2);
+  });
+
+  it('renders feedback model options', () => {
+    const { getByText } = render(ModelSelector, {
+      props: { AIModelProviders: providers, feedbackModels: models },
+    });
+    expect(getByText('GPT-4o')).toBeInTheDocument();
+    expect(getByText('Claude Sonnet')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/PromptList.test.js
+++ b/frontend/src/tests/components/PromptList.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import PromptList from '../../components/PromptList.svelte';
+
+const prompts = [
+  { content: 'Discuss the impact of technology on education.' },
+  { content: 'Some people believe that universities should focus on skills.' },
+];
+
+describe('PromptList component', () => {
+  it('renders all prompt items', () => {
+    const { getByText } = render(PromptList, {
+      props: { prompts, activePromptContent: '' },
+    });
+    expect(getByText('Discuss the impact of technology on education.')).toBeInTheDocument();
+    expect(getByText('Some people believe that universities should focus on skills.')).toBeInTheDocument();
+  });
+
+  it('applies active class to matching prompt', () => {
+    const { container } = render(PromptList, {
+      props: { prompts, activePromptContent: prompts[0].content },
+    });
+    const activeItems = container.querySelectorAll('.prompt-item.active');
+    expect(activeItems.length).toBe(1);
+    expect(activeItems[0].textContent).toContain('Discuss the impact');
+  });
+
+  it('calls onSelectPrompt with prompt object on click', async () => {
+    const onSelectPrompt = vi.fn();
+    const { getByText } = render(PromptList, {
+      props: { prompts, activePromptContent: '', onSelectPrompt },
+    });
+    await fireEvent.click(getByText('Discuss the impact of technology on education.'));
+    expect(onSelectPrompt).toHaveBeenCalledWith(prompts[0]);
+  });
+
+  it('keyboard Enter triggers onSelectPrompt', async () => {
+    const onSelectPrompt = vi.fn();
+    const { getByText } = render(PromptList, {
+      props: { prompts, activePromptContent: '', onSelectPrompt },
+    });
+    await fireEvent.keyDown(getByText('Discuss the impact of technology on education.'), { key: 'Enter' });
+    expect(onSelectPrompt).toHaveBeenCalledWith(prompts[0]);
+  });
+});

--- a/frontend/src/tests/components/ScoreCard.test.js
+++ b/frontend/src/tests/components/ScoreCard.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import ScoreCard from '../../components/ScoreCard.svelte';
+
+const feedback = {
+  overall_score: 7.5,
+  feedback_by_criteria: {
+    taskResponse: { score: 8 },
+    coherenceCohesion: { score: 5 },
+  },
+};
+
+const criteriaLabels = {
+  taskResponse: 'Task Response',
+  coherenceCohesion: 'Coherence & Cohesion',
+};
+
+describe('ScoreCard component', () => {
+  it('renders nothing when feedback is null', () => {
+    const { container } = render(ScoreCard, { props: { feedback: null } });
+    expect(container.querySelector('.score-card')).toBeNull();
+  });
+
+  it('renders overall score value', () => {
+    const { getByText } = render(ScoreCard, {
+      props: { feedback, criteriaLabels, maxScore: 9 },
+    });
+    expect(getByText('7.5')).toBeInTheDocument();
+  });
+
+  it('renders band label for IELTS (maxScore=9)', () => {
+    const { getByText } = render(ScoreCard, {
+      props: { feedback, criteriaLabels, maxScore: 9 },
+    });
+    // 7.5 >= 7.5 -> 'Very Good'
+    expect(getByText('Very Good')).toBeInTheDocument();
+  });
+
+  it('does not render band label when maxScore is not 9', () => {
+    const { container } = render(ScoreCard, {
+      props: { feedback, criteriaLabels, maxScore: 60 },
+    });
+    expect(container.querySelector('.band-label')).toBeNull();
+  });
+
+  it('renders per-criteria scores with mapped labels', () => {
+    const { getByText } = render(ScoreCard, {
+      props: { feedback, criteriaLabels, maxScore: 9 },
+    });
+    expect(getByText('Task Response')).toBeInTheDocument();
+    expect(getByText('Coherence & Cohesion')).toBeInTheDocument();
+    expect(getByText('8')).toBeInTheDocument();
+    expect(getByText('5')).toBeInTheDocument();
+  });
+
+  it('falls back to criterion key when label not provided', () => {
+    const { getByText } = render(ScoreCard, {
+      props: { feedback, criteriaLabels: {}, maxScore: 9 },
+    });
+    expect(getByText('taskResponse')).toBeInTheDocument();
+    expect(getByText('coherenceCohesion')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/TabBar.test.js
+++ b/frontend/src/tests/components/TabBar.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import TabBar from '../../components/TabBar.svelte';
+
+const tabs = [
+  { id: 'tab1', label: 'First' },
+  { id: 'tab2', label: 'Second' },
+  { id: 'tab3', label: 'Third', disabled: true },
+];
+
+describe('TabBar component', () => {
+  it('renders all tab labels', () => {
+    const { getByText } = render(TabBar, { props: { tabs, activeTab: 'tab1' } });
+    expect(getByText('First')).toBeInTheDocument();
+    expect(getByText('Second')).toBeInTheDocument();
+    expect(getByText('Third')).toBeInTheDocument();
+  });
+
+  it('marks the active tab with active class', () => {
+    const { getByText } = render(TabBar, { props: { tabs, activeTab: 'tab2' } });
+    expect(getByText('Second').classList.contains('active')).toBe(true);
+    expect(getByText('First').classList.contains('active')).toBe(false);
+  });
+
+  it('calls onTabChange with tab id on click', async () => {
+    const onTabChange = vi.fn();
+    const { getByText } = render(TabBar, {
+      props: { tabs, activeTab: 'tab1', onTabChange },
+    });
+    await fireEvent.click(getByText('First'));
+    expect(onTabChange).toHaveBeenCalledWith('tab1');
+  });
+
+  it('does not call onTabChange on disabled tab click', async () => {
+    const onTabChange = vi.fn();
+    const { getByText } = render(TabBar, {
+      props: { tabs, activeTab: 'tab1', onTabChange },
+    });
+    await fireEvent.click(getByText('Third'));
+    expect(onTabChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/tests/components/TopBar.test.js
+++ b/frontend/src/tests/components/TopBar.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+
+const { mockIsLogin, mockIsSignUpPage, mockAccessToken, mockUserEmail } = vi.hoisted(() => {
+  const { writable } = require('svelte/store');
+  return {
+    mockIsLogin: writable(false),
+    mockIsSignUpPage: writable(false),
+    mockAccessToken: writable(''),
+    mockUserEmail: writable(''),
+  };
+});
+
+vi.mock('../../lib/store', () => ({
+  isLogin: mockIsLogin,
+  isSignUpPage: mockIsSignUpPage,
+  accessToken: mockAccessToken,
+  userEmail: mockUserEmail,
+}));
+
+import TopBar from '../../components/TopBar.svelte';
+
+describe('TopBar component', () => {
+  beforeEach(() => {
+    mockIsLogin.set(false);
+  });
+
+  it('renders domain name', () => {
+    const { getByText } = render(TopBar, {
+      props: { domainName: 'IELTS Feedback Writer' },
+    });
+    expect(getByText('IELTS Feedback Writer')).toBeInTheDocument();
+  });
+
+  it('shows back button when showBackLink is true', () => {
+    const { container } = render(TopBar, {
+      props: { showBackLink: true },
+    });
+    const buttons = container.querySelectorAll('button');
+    const backBtn = Array.from(buttons).find(b => b.querySelector('svg'));
+    expect(backBtn).toBeTruthy();
+  });
+
+  it('hides back button when showBackLink is false', () => {
+    const { queryByText } = render(TopBar, {
+      props: { showBackLink: false },
+    });
+    expect(queryByText('Info')).toBeInTheDocument();
+  });
+
+  it('shows login/signup buttons when not logged in', () => {
+    const { getByText } = render(TopBar, { props: {} });
+    expect(getByText('Log In')).toBeInTheDocument();
+    expect(getByText('Sign Up')).toBeInTheDocument();
+  });
+
+  it('calls onInfoClick on info button click', async () => {
+    const onInfoClick = vi.fn();
+    const { getByText } = render(TopBar, { props: { onInfoClick } });
+    await fireEvent.click(getByText('Info'));
+    expect(onInfoClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Korean labels when locale is ko', () => {
+    const { getByText } = render(TopBar, { props: { locale: 'ko' } });
+    expect(getByText('로그인')).toBeInTheDocument();
+    expect(getByText('회원가입')).toBeInTheDocument();
+    expect(getByText('안내')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/_DropdownWrapper.svelte
+++ b/frontend/src/tests/components/_DropdownWrapper.svelte
@@ -1,0 +1,11 @@
+<script>
+  import Dropdown from '../../components/Dropdown.svelte';
+  export let align = 'left';
+</script>
+
+<Dropdown {align}>
+  <button slot="trigger" let:toggle on:click={toggle} data-testid="trigger">Toggle</button>
+  <div slot="menu" let:close>
+    <button on:click={close} data-testid="menu-item">Menu Item</button>
+  </div>
+</Dropdown>

--- a/frontend/src/tests/routes/Auth.test.js
+++ b/frontend/src/tests/routes/Auth.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+const { mockIsLogin, mockIsSignUpPage, mockAccessToken, mockUserEmail } = vi.hoisted(() => {
+  const { writable } = require('svelte/store');
+  return {
+    mockIsLogin: writable(false),
+    mockIsSignUpPage: writable(false),
+    mockAccessToken: writable(''),
+    mockUserEmail: writable(''),
+  };
+});
+
+vi.mock('../../lib/store', () => ({
+  isLogin: mockIsLogin,
+  isSignUpPage: mockIsSignUpPage,
+  accessToken: mockAccessToken,
+  userEmail: mockUserEmail,
+}));
+
+vi.mock('svelte-spa-router', () => ({
+  push: vi.fn(),
+  link: vi.fn(() => () => {}),
+}));
+
+vi.mock('../../lib/api', () => ({
+  default: vi.fn(),
+}));
+
+import Auth from '../../routes/Auth.svelte';
+
+describe('Auth route', () => {
+  it('renders login heading by default', () => {
+    const { container } = render(Auth);
+    const heading = container.querySelector('h1');
+    expect(heading).not.toBeNull();
+    expect(heading.textContent).toBe('Log in');
+  });
+
+  it('renders email and password input fields', () => {
+    const { container } = render(Auth);
+    const emailInput = container.querySelector('#email');
+    const passwordInput = container.querySelector('#password');
+    expect(emailInput).not.toBeNull();
+    expect(emailInput.type).toBe('email');
+    expect(passwordInput).not.toBeNull();
+    expect(passwordInput.type).toBe('password');
+  });
+
+  it('renders toggle link to switch to signup', () => {
+    const { getByText } = render(Auth);
+    expect(getByText("Don't have an account? Sign up")).toBeInTheDocument();
+  });
+
+  it('renders forgot password link', () => {
+    const { getByText } = render(Auth);
+    expect(getByText('Forgot your password?')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/routes/DomainSelector.test.js
+++ b/frontend/src/tests/routes/DomainSelector.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+
+const { mockPush } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+}));
+
+vi.mock('svelte-spa-router', () => ({
+  push: mockPush,
+  link: vi.fn(),
+}));
+
+import DomainSelector from '../../routes/DomainSelector.svelte';
+
+describe('DomainSelector route', () => {
+  it('renders all four domain cards', () => {
+    const { getByText } = render(DomainSelector);
+    expect(getByText('IELTS Writing')).toBeInTheDocument();
+    expect(getByText('대학별 논술')).toBeInTheDocument();
+    expect(getByText('Math Problem Solving')).toBeInTheDocument();
+    expect(getByText('Science Essays')).toBeInTheDocument();
+  });
+
+  it('shows COMING SOON badge on disabled domains', () => {
+    const { getAllByText } = render(DomainSelector);
+    const badges = getAllByText('COMING SOON');
+    expect(badges.length).toBe(2);
+  });
+
+  it('enabled domains have clickable class', () => {
+    const { container } = render(DomainSelector);
+    const clickableCards = container.querySelectorAll('.domain-card.clickable');
+    const disabledCards = container.querySelectorAll('.domain-card.disabled');
+    expect(clickableCards.length).toBe(2);
+    expect(disabledCards.length).toBe(2);
+  });
+
+  it('clicking enabled domain navigates to route', async () => {
+    mockPush.mockClear();
+    const { getByText } = render(DomainSelector);
+    await fireEvent.click(getByText('IELTS Writing'));
+    expect(mockPush).toHaveBeenCalledWith('/ielts');
+  });
+
+  it('clicking disabled domain does not navigate', async () => {
+    mockPush.mockClear();
+    const { getByText } = render(DomainSelector);
+    await fireEvent.click(getByText('Math Problem Solving'));
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -12,5 +12,6 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/tests/setup.js'],
+    exclude: ['e2e/**', 'node_modules/**'],
   }
 })


### PR DESCRIPTION
## Summary
- Add conftest fixtures (`test_prompt`, `test_bot`) and 7 CRUD test files (ai_provider, api_model, bot, essay, feedback, prompt, user_api_key)
- Add route tests for IELTS, KSAT, and shared endpoints, plus expanded aggregator rounding tests
- Add 10 frontend component tests + 2 route tests (Vitest + @testing-library/svelte)
- Add Playwright e2e setup and GitHub Actions CI workflow for frontend

## Test plan
- [ ] Run backend tests: `docker-compose exec backend bash ./scripts/test.sh`
- [ ] Run frontend tests: `cd frontend && npm test`
- [ ] Verify CI workflow triggers on push to `main` with `frontend/**` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)