### PR TITLE
feat(ksat-ui): per-question tab isolation with filled-state indicators

### DIFF
--- a/frontend/src/routes/KSATFeedbackWriter.svelte
+++ b/frontend/src/routes/KSATFeedbackWriter.svelte
@@ -5,7 +5,7 @@
   import { onMount, tick } from 'svelte';
   import { push } from 'svelte-spa-router';
   import './home.css';
-  import { BookOpen, FileText, BarChart, PenLine, Search } from 'lucide-svelte';
+  import { BookOpen, FileText, BarChart, PenLine, Search, Check, Circle } from 'lucide-svelte';
 
   import Error from '../components/Error.svelte';
   import TopBar from '../components/TopBar.svelte';
@@ -199,6 +199,15 @@
   $: anyEssayFilled = questions.length > 0 &&
     questions.some(q => (essayContents[q.question_number] || '').trim().length > 0);
 
+  // All questions have content
+  $: allEssaysFilled = questions.length > 0 &&
+    questions.every(q => (essayContents[q.question_number] || '').trim().length > 0);
+
+  // Filled count for progress display
+  $: filledCount = questions.filter(
+    q => (essayContents[q.question_number] || '').trim().length > 0
+  ).length;
+
   async function submitAndGenerateFeedback() {
     if (!anyEssayFilled || isGeneratingFeedback) return;
 
@@ -206,6 +215,17 @@
     const filledQuestions = questions.filter(
       q => (essayContents[q.question_number] || '').trim().length > 0
     );
+
+    if (!allEssaysFilled) {
+      const unfilled = questions
+        .filter(q => (essayContents[q.question_number] || '').trim().length === 0)
+        .map(q => `문제 ${q.question_number}`)
+        .join(', ');
+      const proceed = confirm(
+        `아직 작성하지 않은 답안이 있습니다 (${unfilled}).\n그래도 제출하시겠습니까? 해당 문제는 채점 및 첨삭이 진행되지 않습니다.`
+      );
+      if (!proceed) return;
+    }
 
     isGeneratingFeedback = true;
     try {
@@ -423,18 +443,28 @@
               {#if questions.length > 1}
                 <div class="passage-question-tabs">
                   {#each questions as q (q.question_number)}
+                    {@const filled = (essayContents[q.question_number] || '').trim().length > 0}
                     <button
                       class="passage-question-tab"
                       class:active={activePassageQNum === q.question_number}
+                      class:filled
                       on:click={() => (activePassageQNum = q.question_number)}
+                      aria-label={filled ? `문제 ${q.question_number} (작성 완료)` : `문제 ${q.question_number} (미작성)`}
                     >
+                      <span class="tab-status-icon" aria-hidden="true">
+                        {#if filled}
+                          <Check size={14} strokeWidth={3} />
+                        {:else}
+                          <Circle size={14} strokeWidth={2} />
+                        {/if}
+                      </span>
                       문제 {q.question_number}
                     </button>
                   {/each}
                 </div>
               {/if}
             </div>
-            {#each questions as q (q.question_number)}
+            {#each questions.filter(q => q.question_number === activePassageQNum) as q (q.question_number)}
               <div class="question-write-section">
                 <div class="question-write-header">
                   <span class="question-write-label">[문제 {q.question_number}]</span>
@@ -466,13 +496,22 @@
                   {feedbackModels}
                   bind:selectedFeedbackModel
                 />
-                <button
-                  class="btn btn-primary"
-                  on:click={submitAndGenerateFeedback}
-                  disabled={!anyEssayFilled || isGeneratingFeedback}
-                >
-                  {isGeneratingFeedback ? '채점 중...' : '채점 받기'}
-                </button>
+                <div class="submit-group">
+                  <span class="progress-text" class:complete={allEssaysFilled}>
+                    {#if allEssaysFilled}
+                      모든 문제 작성 완료 ({filledCount}/{questions.length})
+                    {:else}
+                      작성 완료 {filledCount}/{questions.length}
+                    {/if}
+                  </span>
+                  <button
+                    class="btn btn-primary"
+                    on:click={submitAndGenerateFeedback}
+                    disabled={!anyEssayFilled || isGeneratingFeedback}
+                  >
+                    {isGeneratingFeedback ? '채점 중...' : '채점 받기'}
+                  </button>
+                </div>
               </div>
             {:else}
               <div class="empty-message">기출문제 탭에서 문제를 확인한 후 답안을 작성하세요.</div>
@@ -985,13 +1024,17 @@
   }
 
   .passage-question-tab {
-    padding: 4px 10px;
-    border: 1px solid #e5e7eb;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border: 2px solid #e5e7eb;
     border-radius: 6px;
     background: #fff;
     color: #6b7280;
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 500;
+    line-height: 1.2;
     cursor: pointer;
     transition: all 0.15s;
   }
@@ -1001,10 +1044,42 @@
     color: #c44536;
   }
 
+  .passage-question-tab.filled {
+    border-color: #16a34a;
+    background: #f0fdf4;
+    color: #15803d;
+  }
+
+  .passage-question-tab.filled:hover {
+    border-color: #15803d;
+    color: #166534;
+  }
+
   .passage-question-tab.active {
     background: #c44536;
     color: white;
     border-color: #c44536;
+  }
+
+  .passage-question-tab.filled.active {
+    background: #c44536;
+    border-color: #c44536;
+    color: white;
+  }
+
+  .tab-status-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #d1d5db;
+  }
+
+  .passage-question-tab.filled .tab-status-icon {
+    color: #16a34a;
+  }
+
+  .passage-question-tab.active .tab-status-icon {
+    color: rgba(255, 255, 255, 0.95);
   }
 
   .panel-title {
@@ -1087,6 +1162,23 @@
     margin-top: 12px;
     flex-wrap: wrap;
     gap: 8px;
+  }
+
+  .submit-group {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .progress-text {
+    font-size: 13px;
+    font-weight: 500;
+    color: #6b7280;
+  }
+
+  .progress-text.complete {
+    color: #16a34a;
   }
 
   .btn-primary:disabled {

--- a/frontend/src/routes/KSATFeedbackWriter.svelte
+++ b/frontend/src/routes/KSATFeedbackWriter.svelte
@@ -5,12 +5,13 @@
   import { onMount, tick } from 'svelte';
   import { push } from 'svelte-spa-router';
   import './home.css';
-  import { BookOpen, FileText, BarChart, PenLine, Search, Check, Circle } from 'lucide-svelte';
+  import { BookOpen, FileText, BarChart, PenLine, Search, Check, Circle, AlertTriangle } from 'lucide-svelte';
 
   import Error from '../components/Error.svelte';
   import TopBar from '../components/TopBar.svelte';
   import InfoDeskModal from '../components/InfoDeskModal.svelte';
   import ManageKeyModal from '../components/ManageKeyModal.svelte';
+  import Modal from '../components/Modal.svelte';
   import ModelSelector from '../components/ModelSelector.svelte';
   import ScoreCard from '../components/ScoreCard.svelte';
   import { safeHtml } from '../lib/sanitize.js';
@@ -47,6 +48,27 @@
   let isGeneratingFeedback = false;
   let criteriaLabelsMap = {};
   let hasApiKeys = null;
+
+  // Submit confirmation modal state
+  let showSubmitConfirm = false;
+  let unfilledLabels = '';
+  let submitConfirmResolver = null;
+
+  function askSubmitConfirm(label) {
+    unfilledLabels = label;
+    showSubmitConfirm = true;
+    return new Promise((resolve) => {
+      submitConfirmResolver = resolve;
+    });
+  }
+
+  function resolveSubmitConfirm(proceed) {
+    showSubmitConfirm = false;
+    if (submitConfirmResolver) {
+      submitConfirmResolver(proceed);
+      submitConfirmResolver = null;
+    }
+  }
 
   function checkApiKeys() {
     fastapi('get', '/api/v1/shared/api_keys', {},
@@ -221,9 +243,7 @@
         .filter(q => (essayContents[q.question_number] || '').trim().length === 0)
         .map(q => `문제 ${q.question_number}`)
         .join(', ');
-      const proceed = confirm(
-        `아직 작성하지 않은 답안이 있습니다 (${unfilled}).\n그래도 제출하시겠습니까? 해당 문제는 채점 및 첨삭이 진행되지 않습니다.`
-      );
+      const proceed = await askSubmitConfirm(unfilled);
       if (!proceed) return;
     }
 
@@ -330,6 +350,31 @@
   {AIModelProviders}
   locale="ko"
 />
+
+<Modal
+  open={showSubmitConfirm}
+  title="미작성 답안이 있습니다"
+  size="md"
+  onClose={() => resolveSubmitConfirm(false)}
+>
+  <svelte:fragment slot="icon">
+    <span class="submit-confirm-icon"><AlertTriangle size={18} /></span>
+  </svelte:fragment>
+
+  <div class="submit-confirm-body">
+    <p class="submit-confirm-lead">아직 작성하지 않은 답안이 있습니다.</p>
+    <div class="submit-confirm-unfilled">{unfilledLabels}</div>
+    <p class="submit-confirm-note">
+      그대로 제출하면 해당 문제는 <strong>채점 및 첨삭이 진행되지 않습니다.</strong>
+      계속 진행하시겠습니까?
+    </p>
+  </div>
+
+  <svelte:fragment slot="footer">
+    <button type="button" class="btn btn-secondary" on:click={() => resolveSubmitConfirm(false)}>취소</button>
+    <button type="button" class="btn btn-primary" on:click={() => resolveSubmitConfirm(true)}>그래도 제출</button>
+  </svelte:fragment>
+</Modal>
 
 <div class="ksat-layout">
   <!-- Left Sidebar -->
@@ -1371,6 +1416,52 @@
   }
   @keyframes spin {
     to { transform: rotate(360deg); }
+  }
+
+  /* Submit confirmation modal */
+  .submit-confirm-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: #fef3c7;
+    color: #b45309;
+    margin-right: 10px;
+  }
+
+  .submit-confirm-body {
+    padding: 4px 0;
+  }
+
+  .submit-confirm-lead {
+    font-size: 15px;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0 0 12px 0;
+  }
+
+  .submit-confirm-unfilled {
+    background: #fef3c7;
+    color: #92400e;
+    border-left: 3px solid #f59e0b;
+    border-radius: 6px;
+    padding: 10px 14px;
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: 14px;
+  }
+
+  .submit-confirm-note {
+    font-size: 14px;
+    line-height: 1.6;
+    color: #374151;
+    margin: 0;
+  }
+
+  .submit-confirm-note strong {
+    color: #b91c1c;
   }
 
   .onboarding-banner {

--- a/frontend/src/tests/routes/KSATFeedbackWriter.test.js
+++ b/frontend/src/tests/routes/KSATFeedbackWriter.test.js
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+
+const { mockIsLogin, mockIsSignUpPage, mockAccessToken, mockUserEmail } = vi.hoisted(() => {
+  const { writable } = require('svelte/store');
+  return {
+    mockIsLogin: writable(true),
+    mockIsSignUpPage: writable(false),
+    mockAccessToken: writable('test-token'),
+    mockUserEmail: writable('test@test.com'),
+  };
+});
+
+vi.mock('../../lib/store.js', () => ({
+  isLogin: mockIsLogin,
+  isSignUpPage: mockIsSignUpPage,
+  accessToken: mockAccessToken,
+  userEmail: mockUserEmail,
+}));
+
+vi.mock('svelte-spa-router', () => ({
+  push: vi.fn(),
+  link: vi.fn(() => () => {}),
+}));
+
+const { fastapiMock, apiCallMock } = vi.hoisted(() => ({
+  fastapiMock: vi.fn(),
+  apiCallMock: vi.fn(),
+}));
+
+vi.mock('../../lib/api.js', () => ({
+  default: fastapiMock,
+  apiCall: apiCallMock,
+  fastapiUpload: vi.fn(),
+}));
+
+import KSATFeedbackWriter from '../../routes/KSATFeedbackWriter.svelte';
+
+const EXAM ={
+  id: 1,
+  university: '중앙대학교',
+  year: 2025,
+  track: 'humanities',
+  exam_type: 'mock',
+};
+
+const QUESTIONS = [
+  { question_number: 1, prompt_id: 101, prompt_content: '문제1 본문', max_points: 40, rubric_name: 'r1', content: '<p>제시문1</p>', char_min: 0, char_max: 0 },
+  { question_number: 2, prompt_id: 102, prompt_content: '문제2 본문', max_points: 30, rubric_name: 'r1', content: '<p>제시문2</p>', char_min: 0, char_max: 0 },
+  { question_number: 3, prompt_id: 103, prompt_content: '문제3 본문', max_points: 30, rubric_name: 'r1', content: '<p>제시문3</p>', char_min: 0, char_max: 0 },
+];
+
+function installFastapiMock() {
+  fastapiMock.mockImplementation((op, url, params, onSuccess, onFailure) => {
+    if (url === '/api/v1/user/auth') {
+      onSuccess && onSuccess();
+    } else if (url === '/api/v1/shared/api_keys') {
+      onSuccess && onSuccess([{ id: 1 }]);
+    } else if (url === '/api/v1/shared/providers') {
+      onSuccess && onSuccess([{ id: 1, name: 'OpenAI' }]);
+    } else if (url.startsWith('/api/v1/shared/api_models/')) {
+      onSuccess && onSuccess([{ id: 1, api_model_name: 'gpt-4', alias: 'GPT-4', bot: { id: 1 } }]);
+    } else if (url === '/api/v1/ksat/exams') {
+      onSuccess && onSuccess([EXAM]);
+    } else if (/^\/api\/v1\/ksat\/exams\/\d+$/.test(url)) {
+      onSuccess && onSuccess({ questions: QUESTIONS });
+    } else if (url === '/api/v1/ksat/essays') {
+      onSuccess && onSuccess([]);
+    } else if (url === '/api/v1/ksat/feedbacks') {
+      onSuccess && onSuccess([]);
+    } else if (url === '/api/v1/ksat/criteria') {
+      onSuccess && onSuccess([]);
+    } else if (url === '/api/v1/ksat/example') {
+      onSuccess && onSuccess({ content: '' });
+    }
+  });
+}
+
+async function navigateToWriteTab(result) {
+  // Select university
+  await waitFor(() => {
+    expect(result.getByText('중앙대학교')).toBeInTheDocument();
+  });
+  await fireEvent.click(result.getByText('중앙대학교'));
+
+  // Select exam
+  await waitFor(() => {
+    expect(result.container.querySelector('.exam-list-item')).not.toBeNull();
+  });
+  await fireEvent.click(result.container.querySelector('.exam-list-item'));
+
+  // Wait for write tab to render with 3 question tabs
+  await waitFor(() => {
+    const tabs = result.container.querySelectorAll('.passage-question-tab');
+    expect(tabs.length).toBe(3);
+  });
+}
+
+describe('KSATFeedbackWriter - 문제 tab 활성화', () => {
+  beforeEach(() => {
+    fastapiMock.mockReset();
+    apiCallMock.mockReset();
+    installFastapiMock();
+  });
+
+  it('fills tab 1 with Check icon, leaves tabs 2/3 with Circle icon and shows "작성 완료 1/3"', async () => {
+    const result = render(KSATFeedbackWriter);
+    await navigateToWriteTab(result);
+
+    // 문제 1 text area에 "test" 작성 (active tab defaults to question 1)
+    const textarea = result.container.querySelector('.essay-textarea');
+    expect(textarea).not.toBeNull();
+    await fireEvent.input(textarea, { target: { value: 'test' } });
+
+    // Wait for reactivity to flush
+    await waitFor(() => {
+      const progressEl = result.container.querySelector('.progress-text');
+      expect(progressEl.textContent).toMatch(/작성 완료 1\s*\/\s*3/);
+    });
+
+    const tabs = result.container.querySelectorAll('.passage-question-tab');
+
+    // 문제 1 tab: filled class + Check icon (no <circle> element inside svg)
+    expect(tabs[0].classList.contains('filled')).toBe(true);
+    const icon1 = tabs[0].querySelector('.tab-status-icon svg');
+    expect(icon1).not.toBeNull();
+    expect(icon1.querySelector('circle')).toBeNull();
+
+    // 문제 2, 3 tab: no filled class + Circle icon (contains <circle> element)
+    expect(tabs[1].classList.contains('filled')).toBe(false);
+    expect(tabs[2].classList.contains('filled')).toBe(false);
+    const icon2 = tabs[1].querySelector('.tab-status-icon svg');
+    const icon3 = tabs[2].querySelector('.tab-status-icon svg');
+    expect(icon2.querySelector('circle')).not.toBeNull();
+    expect(icon3.querySelector('circle')).not.toBeNull();
+  });
+});
+
+describe('KSATFeedbackWriter - 채점 받기 button', () => {
+  beforeEach(() => {
+    fastapiMock.mockReset();
+    apiCallMock.mockReset();
+    installFastapiMock();
+    apiCallMock.mockResolvedValue({ id: 999, submitted_at: '2025-01-01', prompt_id: 101 });
+  });
+
+  async function fillQuestion(result, tabIndex, text) {
+    const tabs = result.container.querySelectorAll('.passage-question-tab');
+    await fireEvent.click(tabs[tabIndex]);
+    await waitFor(() => {
+      const textarea = result.container.querySelector('.essay-textarea');
+      const header = result.container.querySelector('.question-write-label');
+      expect(header.textContent).toContain(`문제 ${tabIndex + 1}`);
+      expect(textarea).not.toBeNull();
+    });
+    const textarea = result.container.querySelector('.essay-textarea');
+    await fireEvent.input(textarea, { target: { value: text } });
+  }
+
+  it('shows warning modal when only some questions are filled', async () => {
+    const result = render(KSATFeedbackWriter);
+    await navigateToWriteTab(result);
+
+    await fillQuestion(result, 0, 'test');
+
+    await fireEvent.click(result.getByText('채점 받기'));
+
+    await waitFor(() => {
+      expect(result.getByText('미작성 답안이 있습니다')).toBeInTheDocument();
+    });
+    // Unfilled labels should include 문제 2, 문제 3
+    const unfilledBox = result.container.querySelector('.submit-confirm-unfilled');
+    expect(unfilledBox.textContent).toContain('문제 2');
+    expect(unfilledBox.textContent).toContain('문제 3');
+  });
+
+  it('does NOT show the modal when all questions are filled', async () => {
+    const result = render(KSATFeedbackWriter);
+    await navigateToWriteTab(result);
+
+    await fillQuestion(result, 0, 'answer-1');
+    await fillQuestion(result, 1, 'answer-2');
+    await fillQuestion(result, 2, 'answer-3');
+
+    await fireEvent.click(result.getByText('채점 받기'));
+
+    // Modal should not appear
+    expect(result.queryByText('미작성 답안이 있습니다')).toBeNull();
+
+    // apiCall should be invoked for essay submission
+    await waitFor(() => {
+      expect(apiCallMock).toHaveBeenCalled();
+    });
+  });
+
+  it('does NOT call apiCall when 취소 is clicked on the modal', async () => {
+    const result = render(KSATFeedbackWriter);
+    await navigateToWriteTab(result);
+
+    await fillQuestion(result, 0, 'test');
+
+    await fireEvent.click(result.getByText('채점 받기'));
+
+    await waitFor(() => {
+      expect(result.getByText('미작성 답안이 있습니다')).toBeInTheDocument();
+    });
+
+    await fireEvent.click(result.getByText('취소'));
+
+    await waitFor(() => {
+      expect(result.queryByText('미작성 답안이 있습니다')).toBeNull();
+    });
+    expect(apiCallMock).not.toHaveBeenCalled();
+  });
+
+  it('calls apiCall when 그래도 제출 is clicked on the modal', async () => {
+    const result = render(KSATFeedbackWriter);
+    await navigateToWriteTab(result);
+
+    await fillQuestion(result, 0, 'test');
+
+    await fireEvent.click(result.getByText('채점 받기'));
+
+    await waitFor(() => {
+      expect(result.getByText('미작성 답안이 있습니다')).toBeInTheDocument();
+    });
+
+    await fireEvent.click(result.getByText('그래도 제출'));
+
+    await waitFor(() => {
+      expect(apiCallMock).toHaveBeenCalled();
+    });
+    // Only filled question (문제 1) should be submitted as an essay
+    expect(apiCallMock).toHaveBeenCalledWith(
+      'post',
+      '/api/v1/ksat/essays',
+      expect.objectContaining({ prompt_id: 101, content: 'test' }),
+    );
+    // Unfilled questions (prompt_id 102, 103) should NOT be submitted
+    const submittedPromptIds = apiCallMock.mock.calls
+      .filter(([op, url]) => url === '/api/v1/ksat/essays')
+      .map(([, , params]) => params.prompt_id);
+    expect(submittedPromptIds).not.toContain(102);
+    expect(submittedPromptIds).not.toContain(103);
+  });
+});


### PR DESCRIPTION
## Summary
- KSAT 답안 작성 탭에서 선택된 문제의 essay 입력란만 보이도록 변경 (문제 수가 많을 때 스크롤/혼선 감소)
- 각 문제 탭에 작성 여부 인디케이터(Check/Circle 아이콘 + 초록 테두리 + 연한 초록 배경) 추가
- 제출 버튼 옆에 `작성 완료 n/N` 진행도 텍스트 추가 (전부 채우면 초록색)
- 일부 문제가 미작성된 상태로 제출 시 `confirm()` 경고 — 취소 시 제출 중단
- 탭 폰트 크기를 14px로 통일해 `제시문` / `답안 작성` 패널 제목과 정렬

## Test plan
- [ ] 문제가 2개 이상인 시험(예: CAU 2025 인문)을 선택했을 때 탭 전환으로 해당 문제의 textarea만 표시되는지 확인
- [ ] 문제 탭에서 작성 / 미작성 상태 변화 시 체크 아이콘과 테두리 색이 실시간으로 갱신되는지 확인
- [ ] 모든 문제 작성 시 진행도 텍스트가 "모든 문제 작성 완료 (N/N)" + 초록색으로 바뀌는지 확인
- [ ] 일부 문제만 채운 상태에서 `채점 받기` 클릭 시 경고 모달이 뜨고, 취소하면 제출되지 않는지 확인
- [ ] 확인 시 채워진 문제에 대해서만 채점이 진행되는지 확인
- [ ] 모바일(<=768px) 뷰에서 탭/진행도 레이아웃이 깨지지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)