### PR TITLE
feat(ksat): add per-exam duration and writing-tab countdown timer

### DIFF
--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -258,6 +258,7 @@ async def store_ksat_exam_data(db: AsyncSession) -> None:
             year=meta["year"],
             track=track,
             exam_type=exam_type,
+            duration_minutes=meta.get("duration_minutes"),
         )
         db.add(db_exam)
         await db.commit()

--- a/backend/app/data/ksat/2024_cau_mock_essay/humanities/seed.py
+++ b/backend/app/data/ksat/2024_cau_mock_essay/humanities/seed.py
@@ -15,6 +15,7 @@ EXAM_META = {
     "year": 2024,
     "track": "humanities",
     "exam_type": "mock",
+    "duration_minutes": 120,
 }
 
 QUESTIONS = [

--- a/backend/app/data/ksat/2024_cau_official_essay/humanities/seed.py
+++ b/backend/app/data/ksat/2024_cau_official_essay/humanities/seed.py
@@ -14,6 +14,7 @@ EXAM_META = {
     "year": 2024,
     "track": "humanities",
     "exam_type": "official",
+    "duration_minutes": 120,
 }
 
 QUESTIONS = [

--- a/backend/app/data/ksat/2025_cau_mock_essay/humanities/seed.py
+++ b/backend/app/data/ksat/2025_cau_mock_essay/humanities/seed.py
@@ -14,6 +14,7 @@ EXAM_META = {
     "year": 2025,
     "track": "humanities",
     "exam_type": "mock",
+    "duration_minutes": 120,
 }
 
 QUESTIONS = [

--- a/backend/app/data/ksat/2025_cau_official_essay/humanities/seed.py
+++ b/backend/app/data/ksat/2025_cau_official_essay/humanities/seed.py
@@ -14,6 +14,7 @@ EXAM_META = {
     "year": 2025,
     "track": "humanities",
     "exam_type": "official",
+    "duration_minutes": 120,
 }
 
 QUESTIONS = [

--- a/backend/app/data/ksat/2026_inha_mock_essay/humanities/seed.py
+++ b/backend/app/data/ksat/2026_inha_mock_essay/humanities/seed.py
@@ -20,6 +20,7 @@ EXAM_META = {
     "year": 2026,
     "track": "humanities",
     "exam_type": "mock",
+    "duration_minutes": 120,
 }
 
 QUESTIONS = [

--- a/backend/app/migrations/versions/c7d8e9f0a1b2_add_duration_minutes_to_exams.py
+++ b/backend/app/migrations/versions/c7d8e9f0a1b2_add_duration_minutes_to_exams.py
@@ -1,0 +1,42 @@
+"""Add duration_minutes to exams
+
+Adds a nullable duration_minutes column so each exam can declare its own
+time limit (e.g. 120 for CAU/Inha humanities). Seeded rows that predate
+the column are backfilled for universities whose time limit is known;
+unknown combinations stay NULL and the frontend hides the timer.
+
+Revision ID: c7d8e9f0a1b2
+Revises: b6c7d8e9f0a1
+Create Date: 2026-04-25 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c7d8e9f0a1b2"
+down_revision: Union[str, None] = "b6c7d8e9f0a1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "exams",
+        sa.Column("duration_minutes", sa.Integer(), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE exams
+           SET duration_minutes = 120
+         WHERE university IN ('중앙대학교', '인하대학교')
+           AND track = 'humanities'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("exams", "duration_minutes")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -360,6 +360,7 @@ class Exam(Base):
     year = Column(Integer, nullable=False)
     track = Column(Enum(TrackType), nullable=False)
     exam_type = Column(Enum(ExamType), nullable=False, server_default="official")
+    duration_minutes = Column(Integer, nullable=True)
     created_at = Column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),

--- a/backend/app/schemas/exam_schema.py
+++ b/backend/app/schemas/exam_schema.py
@@ -35,6 +35,7 @@ class ExamPublic(BaseModel):
     year: int
     track: str
     exam_type: str
+    duration_minutes: Optional[int] = None
     created_at: datetime
 
 

--- a/backend/app/tests/api/routes/test_ksat.py
+++ b/backend/app/tests/api/routes/test_ksat.py
@@ -98,6 +98,81 @@ async def test_exam_question_content_round_trips(
     await db.commit()
 
 
+async def test_exam_detail_includes_duration_minutes(
+    client: AsyncClient, db: AsyncSession
+) -> None:
+    exam = Exam(
+        domain=DomainType.ksat,
+        university="Duration Test University",
+        year=2099,
+        track=TrackType.humanities,
+        exam_type=ExamType.mock,
+        duration_minutes=120,
+    )
+    db.add(exam)
+    await db.commit()
+    await db.refresh(exam)
+
+    try:
+        r = await client.get(f"{settings.API_V1_STR}/ksat/exams/{exam.id}")
+        assert r.status_code == 200
+        assert r.json()["duration_minutes"] == 120
+    finally:
+        await db.delete(exam)
+        await db.commit()
+
+
+async def test_exam_list_includes_duration_minutes(
+    client: AsyncClient, db: AsyncSession
+) -> None:
+    exam = Exam(
+        domain=DomainType.ksat,
+        university="Duration List University",
+        year=2098,
+        track=TrackType.humanities,
+        exam_type=ExamType.mock,
+        duration_minutes=90,
+    )
+    db.add(exam)
+    await db.commit()
+    await db.refresh(exam)
+
+    try:
+        r = await client.get(f"{settings.API_V1_STR}/ksat/exams")
+        assert r.status_code == 200
+        matched = next((e for e in r.json() if e["id"] == exam.id), None)
+        assert matched is not None
+        assert matched["duration_minutes"] == 90
+    finally:
+        await db.delete(exam)
+        await db.commit()
+
+
+async def test_exam_duration_minutes_null_when_unset(
+    client: AsyncClient, db: AsyncSession
+) -> None:
+    exam = Exam(
+        domain=DomainType.ksat,
+        university="No Duration University",
+        year=2097,
+        track=TrackType.humanities,
+        exam_type=ExamType.mock,
+    )
+    db.add(exam)
+    await db.commit()
+    await db.refresh(exam)
+
+    try:
+        r = await client.get(f"{settings.API_V1_STR}/ksat/exams/{exam.id}")
+        assert r.status_code == 200
+        body = r.json()
+        assert "duration_minutes" in body
+        assert body["duration_minutes"] is None
+    finally:
+        await db.delete(exam)
+        await db.commit()
+
+
 async def test_submit_and_list_ksat_essays(
     client: AsyncClient,
     db: AsyncSession,

--- a/frontend/src/routes/Auth.svelte
+++ b/frontend/src/routes/Auth.svelte
@@ -23,7 +23,7 @@
       fastapi('login', url, params,
           (json) => {
               $accessToken = json.access_token
-              $userEmail = json.user_email
+              $userEmail = json.email
               $isLogin = true
               push("/")
           },

--- a/frontend/src/routes/KSATFeedbackWriter.svelte
+++ b/frontend/src/routes/KSATFeedbackWriter.svelte
@@ -1,11 +1,11 @@
 <script>
-  import { isLogin, accessToken } from '../lib/store.js';
+  import { isLogin, accessToken, userEmail } from '../lib/store.js';
   import { get } from 'svelte/store';
   import fastapi, { apiCall } from '../lib/api.js';
-  import { onMount, tick } from 'svelte';
+  import { onMount, onDestroy, tick } from 'svelte';
   import { push } from 'svelte-spa-router';
   import './home.css';
-  import { BookOpen, FileText, BarChart, PenLine, Search, Check, Circle, AlertTriangle } from 'lucide-svelte';
+  import { BookOpen, FileText, BarChart, PenLine, Search, Check, Circle, AlertTriangle, Clock, RotateCcw } from 'lucide-svelte';
 
   import Error from '../components/Error.svelte';
   import TopBar from '../components/TopBar.svelte';
@@ -53,6 +53,90 @@
   let showSubmitConfirm = false;
   let unfilledLabels = '';
   let submitConfirmResolver = null;
+
+  // Timer state
+  const WARNING_THRESHOLD_SECONDS = 30 * 60;
+  let timerStartedAt = null; // ms epoch
+  let timerElapsedSeconds = 0;
+  let timerIntervalId = null;
+
+  function timerStorageKey(examId) {
+    const email = get(userEmail) || 'anon';
+    return `ksat_timer_${email}_${examId}`;
+  }
+
+  function startTimerForExam(exam) {
+    if (!exam || !exam.duration_minutes) return;
+    const key = timerStorageKey(exam.id);
+    const stored = localStorage.getItem(key);
+    if (stored) {
+      const parsed = parseInt(stored, 10);
+      if (!Number.isNaN(parsed)) {
+        timerStartedAt = parsed;
+      }
+    }
+    if (!timerStartedAt) {
+      timerStartedAt = Date.now();
+      localStorage.setItem(key, String(timerStartedAt));
+    }
+    tickTimer();
+    if (timerIntervalId) clearInterval(timerIntervalId);
+    timerIntervalId = setInterval(tickTimer, 1000);
+  }
+
+  function tickTimer() {
+    if (!timerStartedAt) return;
+    timerElapsedSeconds = Math.floor((Date.now() - timerStartedAt) / 1000);
+  }
+
+  function stopTimer() {
+    if (timerIntervalId) {
+      clearInterval(timerIntervalId);
+      timerIntervalId = null;
+    }
+  }
+
+  function resetTimer() {
+    if (!selectedExam) return;
+    const key = timerStorageKey(selectedExam.id);
+    timerStartedAt = Date.now();
+    localStorage.setItem(key, String(timerStartedAt));
+    timerElapsedSeconds = 0;
+    if (timerIntervalId) clearInterval(timerIntervalId);
+    timerIntervalId = setInterval(tickTimer, 1000);
+  }
+
+  function clearTimerState() {
+    stopTimer();
+    timerStartedAt = null;
+    timerElapsedSeconds = 0;
+  }
+
+  $: timerDurationSeconds =
+    selectedExam && selectedExam.duration_minutes
+      ? selectedExam.duration_minutes * 60
+      : 0;
+  $: timerRemainingSeconds = timerDurationSeconds
+    ? timerDurationSeconds - timerElapsedSeconds
+    : 0;
+  $: timerIsOver = timerDurationSeconds > 0 && timerRemainingSeconds <= 0;
+  $: timerIsWarning =
+    timerDurationSeconds > 0 &&
+    !timerIsOver &&
+    timerRemainingSeconds <= WARNING_THRESHOLD_SECONDS;
+
+  function formatTimerDisplay(seconds) {
+    if (seconds <= 0) return '00:00';
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = seconds % 60;
+    const pad = (n) => String(n).padStart(2, '0');
+    return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+  }
+
+  onDestroy(() => {
+    stopTimer();
+  });
 
   function askSubmitConfirm(label) {
     unfilledLabels = label;
@@ -129,8 +213,10 @@
 
   // Select an exam and load its details
   function selectExam(exam) {
+    clearTimerState();
     selectedExam = exam;
     mainActiveTab = 'write';
+    startTimerForExam(exam);
     fastapi('get', `/api/v1/ksat/exams/${exam.id}`, {},
       (json) => {
         questions = json.questions || [];
@@ -400,6 +486,7 @@
           class="university-item"
           class:active={selectedUniversity === university}
           on:click={() => {
+            clearTimerState();
             selectedUniversity = university;
             selectedExam = null;
             mainActiveTab = 'prompts';
@@ -484,7 +571,38 @@
 
           <div class="essay-panel">
             <div class="essay-panel-header">
-              <h4 class="panel-title">답안 작성</h4>
+              <div class="essay-panel-header-title">
+                <h4 class="panel-title">답안 작성</h4>
+                {#if selectedExam?.duration_minutes}
+                  <div
+                    class="timer"
+                    class:warning={timerIsWarning}
+                    class:over={timerIsOver}
+                    role="timer"
+                    aria-live="polite"
+                    aria-label={timerIsOver
+                      ? '제한 시간이 초과되었습니다'
+                      : `남은 시간 ${formatTimerDisplay(timerRemainingSeconds)}`}
+                  >
+                    <Clock size={14} aria-hidden="true" />
+                    {#if timerIsOver}
+                      <span class="timer-label">시간 초과</span>
+                    {:else}
+                      <span class="timer-label">남은 시간</span>
+                      <span class="timer-value">{formatTimerDisplay(timerRemainingSeconds)}</span>
+                    {/if}
+                    <button
+                      type="button"
+                      class="timer-reset"
+                      on:click={resetTimer}
+                      aria-label="타이머 재설정"
+                      title="타이머 재설정"
+                    >
+                      <RotateCcw size={13} aria-hidden="true" />
+                    </button>
+                  </div>
+                {/if}
+              </div>
               {#if questions.length > 1}
                 <div class="passage-question-tabs">
                   {#each questions as q (q.question_number)}
@@ -1060,6 +1178,87 @@
 
   .essay-panel-header .panel-title {
     margin: 0;
+  }
+
+  .essay-panel-header-title {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .timer {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 6px;
+    background: #f3f4f6;
+    color: #374151;
+    font-size: 13px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    border: 1px solid #e5e7eb;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+  }
+
+  .timer-label {
+    font-weight: 500;
+    color: #6b7280;
+  }
+
+  .timer-value {
+    font-weight: 700;
+    letter-spacing: 0.02em;
+  }
+
+  .timer.warning {
+    background: #fdf0ee;
+    color: #c44536;
+    border-color: #c44536;
+  }
+
+  .timer.warning .timer-label {
+    color: #c44536;
+  }
+
+  .timer.over {
+    background: #c44536;
+    color: #fff;
+    border-color: #c44536;
+    animation: timer-blink 1s ease-in-out infinite;
+  }
+
+  @keyframes timer-blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.55; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .timer.over { animation: none; }
+  }
+
+  .timer-reset {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px;
+    margin-left: 2px;
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    border-radius: 4px;
+    opacity: 0.7;
+  }
+
+  .timer-reset:hover {
+    opacity: 1;
+    background: rgba(0, 0, 0, 0.06);
+  }
+
+  .timer.over .timer-reset:hover {
+    background: rgba(255, 255, 255, 0.2);
   }
 
   .passage-question-tabs {

--- a/frontend/src/routes/KSATFeedbackWriter.svelte
+++ b/frontend/src/routes/KSATFeedbackWriter.svelte
@@ -61,7 +61,7 @@
   let timerIntervalId = null;
 
   function timerStorageKey(examId) {
-    const email = get(userEmail) || 'anon';
+    const email = get(userEmail) || 'anno';
     return `ksat_timer_${email}_${examId}`;
   }
 

--- a/frontend/src/tests/routes/KSATFeedbackWriter.test.js
+++ b/frontend/src/tests/routes/KSATFeedbackWriter.test.js
@@ -42,6 +42,7 @@ const EXAM ={
   year: 2025,
   track: 'humanities',
   exam_type: 'mock',
+  duration_minutes: null,
 };
 
 const QUESTIONS = [

--- a/frontend/src/tests/routes/KSATFeedbackWriter.timer.test.js
+++ b/frontend/src/tests/routes/KSATFeedbackWriter.timer.test.js
@@ -1,0 +1,428 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+
+const { mockIsLogin, mockIsSignUpPage, mockAccessToken, mockUserEmail } = vi.hoisted(() => {
+  const { writable } = require('svelte/store');
+  return {
+    mockIsLogin: writable(true),
+    mockIsSignUpPage: writable(false),
+    mockAccessToken: writable('test-token'),
+    mockUserEmail: writable('test@test.com'),
+  };
+});
+
+vi.mock('../../lib/store.js', () => ({
+  isLogin: mockIsLogin,
+  isSignUpPage: mockIsSignUpPage,
+  accessToken: mockAccessToken,
+  userEmail: mockUserEmail,
+}));
+
+vi.mock('svelte-spa-router', () => ({
+  push: vi.fn(),
+  link: vi.fn(() => () => {}),
+}));
+
+const { fastapiMock, apiCallMock } = vi.hoisted(() => ({
+  fastapiMock: vi.fn(),
+  apiCallMock: vi.fn(),
+}));
+
+vi.mock('../../lib/api.js', () => ({
+  default: fastapiMock,
+  apiCall: apiCallMock,
+  fastapiUpload: vi.fn(),
+}));
+
+import KSATFeedbackWriter from '../../routes/KSATFeedbackWriter.svelte';
+
+const EXAM_A = {
+  id: 1,
+  university: '중앙대학교',
+  year: 2025,
+  track: 'humanities',
+  exam_type: 'mock',
+  duration_minutes: 120,
+};
+const EXAM_B = {
+  id: 2,
+  university: '중앙대학교',
+  year: 2024,
+  track: 'humanities',
+  exam_type: 'official',
+  duration_minutes: 120,
+};
+const EXAM_NO_TIMER = {
+  id: 3,
+  university: '중앙대학교',
+  year: 2026,
+  track: 'humanities',
+  exam_type: 'mock',
+  duration_minutes: null,
+};
+const EXAM_ZERO = {
+  id: 4,
+  university: '중앙대학교',
+  year: 2027,
+  track: 'humanities',
+  exam_type: 'mock',
+  duration_minutes: 0,
+};
+
+const QUESTIONS = [
+  { question_number: 1, prompt_id: 101, prompt_content: '문제1', max_points: 40, rubric_name: 'r1', content: '<p>p1</p>', char_min: 0, char_max: 0 },
+];
+
+function installFastapiMock(examList) {
+  fastapiMock.mockImplementation((op, url, params, onSuccess) => {
+    if (url === '/api/v1/user/auth') return onSuccess && onSuccess();
+    if (url === '/api/v1/shared/api_keys') return onSuccess && onSuccess([{ id: 1 }]);
+    if (url === '/api/v1/shared/providers')
+      return onSuccess && onSuccess([{ id: 1, name: 'OpenAI' }]);
+    if (url.startsWith('/api/v1/shared/api_models/'))
+      return onSuccess && onSuccess([{ id: 1, api_model_name: 'gpt-4', alias: 'GPT-4', bot: { id: 1 } }]);
+    if (url === '/api/v1/ksat/exams') return onSuccess && onSuccess(examList);
+    const examDetailMatch = url.match(/^\/api\/v1\/ksat\/exams\/(\d+)$/);
+    if (examDetailMatch) {
+      const id = Number(examDetailMatch[1]);
+      const exam = examList.find((e) => e.id === id) || examList[0];
+      return onSuccess && onSuccess({ ...exam, questions: QUESTIONS });
+    }
+    if (url === '/api/v1/ksat/essays') return onSuccess && onSuccess([]);
+    if (url === '/api/v1/ksat/feedbacks') return onSuccess && onSuccess([]);
+    if (url === '/api/v1/ksat/criteria') return onSuccess && onSuccess([]);
+    if (url === '/api/v1/ksat/example') return onSuccess && onSuccess({ content: '' });
+  });
+}
+
+async function selectExamByTitle(result, titleFragment) {
+  await waitFor(() => {
+    expect(result.getByText('중앙대학교')).toBeInTheDocument();
+  });
+  await fireEvent.click(result.getByText('중앙대학교'));
+
+  await waitFor(() => {
+    expect(result.container.querySelector('.exam-list-item')).not.toBeNull();
+  });
+  const items = Array.from(result.container.querySelectorAll('.exam-list-item'));
+  const target = items.find((el) => el.textContent.includes(titleFragment));
+  if (!target) throw new Error(`No exam card matching "${titleFragment}"`);
+  await fireEvent.click(target);
+
+  await waitFor(() => {
+    expect(result.container.querySelector('.essay-textarea')).not.toBeNull();
+  });
+}
+
+const BASE_TIME = new Date('2026-04-25T09:00:00Z');
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval', 'Date'] });
+  vi.setSystemTime(BASE_TIME);
+  localStorage.clear();
+  mockUserEmail.set('test@test.com');
+  fastapiMock.mockReset();
+  apiCallMock.mockReset();
+  installFastapiMock([EXAM_A, EXAM_B, EXAM_NO_TIMER, EXAM_ZERO]);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ───────────────────────────────────────────────────────────
+// A. Storage key
+// ───────────────────────────────────────────────────────────
+describe('Timer — storage key', () => {
+  it('A1: uses ksat_timer_{email}_{examId} when userEmail is populated', async () => {
+    mockUserEmail.set('alice@example.com');
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+
+    expect(localStorage.getItem('ksat_timer_alice@example.com_1')).not.toBeNull();
+  });
+
+  it('A2: falls back to ksat_timer_anon_{examId} when userEmail is empty', async () => {
+    mockUserEmail.set('');
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+
+    expect(localStorage.getItem('ksat_timer_anon_1')).not.toBeNull();
+  });
+});
+
+// ───────────────────────────────────────────────────────────
+// B. Persistence
+// ───────────────────────────────────────────────────────────
+describe('Timer — persistence', () => {
+  it('B1: writes BASE_TIME ms to localStorage on first selectExam', async () => {
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+
+    const stored = localStorage.getItem('ksat_timer_test@test.com_1');
+    expect(Number(stored)).toBe(BASE_TIME.getTime());
+  });
+
+  it('B2: resumes from existing localStorage value without overwriting', async () => {
+    const pastStart = BASE_TIME.getTime() - 60 * 60 * 1000; // 1h ago
+    localStorage.setItem('ksat_timer_test@test.com_1', String(pastStart));
+
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+
+    expect(Number(localStorage.getItem('ksat_timer_test@test.com_1'))).toBe(pastStart);
+
+    // 120 - 60 = 60 min remaining → MM:SS format not used, HH:MM:SS with 01:00:00
+    await waitFor(() => {
+      const timer = result.container.querySelector('.timer');
+      expect(timer.textContent).toContain('01:00:00');
+    });
+  });
+
+  it('B3: tab switching keeps localStorage value and interval count stable', async () => {
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+    const storedInitial = localStorage.getItem('ksat_timer_test@test.com_1');
+    expect(vi.getTimerCount()).toBe(1);
+
+    await fireEvent.click(result.getByRole('button', { name: /기출문제/ }));
+    await fireEvent.click(result.getByRole('button', { name: /답안 작성/ }));
+
+    expect(localStorage.getItem('ksat_timer_test@test.com_1')).toBe(storedInitial);
+    expect(vi.getTimerCount()).toBe(1);
+  });
+});
+
+// ───────────────────────────────────────────────────────────
+// C. Display formatting
+// ───────────────────────────────────────────────────────────
+describe('Timer — display formatting', () => {
+  it('C1: renders HH:MM:SS when more than 1 hour remaining', async () => {
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+
+    await waitFor(() => {
+      const value = result.container.querySelector('.timer-value');
+      // 120 min = 02:00:00 at start
+      expect(value.textContent.trim()).toBe('02:00:00');
+    });
+  });
+
+  it('C2: renders MM:SS when less than 1 hour remaining', async () => {
+    // 70 min already elapsed → 50 min left
+    const past = BASE_TIME.getTime() - 70 * 60 * 1000;
+    localStorage.setItem('ksat_timer_test@test.com_1', String(past));
+
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+
+    await waitFor(() => {
+      const value = result.container.querySelector('.timer-value');
+      expect(value.textContent.trim()).toBe('50:00');
+    });
+  });
+
+  it('C3: shows "시간 초과" and hides numeric value when overtime', async () => {
+    const past = BASE_TIME.getTime() - 125 * 60 * 1000; // 5 min overtime
+    localStorage.setItem('ksat_timer_test@test.com_1', String(past));
+
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+
+    await waitFor(() => {
+      const timer = result.container.querySelector('.timer');
+      expect(timer.textContent).toContain('시간 초과');
+      expect(timer.querySelector('.timer-value')).toBeNull();
+    });
+  });
+});
+
+// ───────────────────────────────────────────────────────────
+// D. Reactive warning / over states
+// ───────────────────────────────────────────────────────────
+describe('Timer — reactive states', () => {
+  it('D1: no warning/over class when plenty of time remains', async () => {
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+
+    const timer = result.container.querySelector('.timer');
+    expect(timer.classList.contains('warning')).toBe(false);
+    expect(timer.classList.contains('over')).toBe(false);
+  });
+
+  it('D2: applies warning class when crossing the 30-min threshold', async () => {
+    // Start with 31 min remaining → not warning yet
+    const past = BASE_TIME.getTime() - (120 - 31) * 60 * 1000;
+    localStorage.setItem('ksat_timer_test@test.com_1', String(past));
+
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+
+    let timer = result.container.querySelector('.timer');
+    expect(timer.classList.contains('warning')).toBe(false);
+
+    // Advance 90s → now ~29:30 left → warning
+    vi.advanceTimersByTime(90 * 1000);
+
+    await waitFor(() => {
+      timer = result.container.querySelector('.timer');
+      expect(timer.classList.contains('warning')).toBe(true);
+      expect(timer.classList.contains('over')).toBe(false);
+    });
+  });
+
+  it('D3: applies over class and drops warning when crossing zero', async () => {
+    // 29 min remaining → warning already active
+    const past = BASE_TIME.getTime() - (120 - 29) * 60 * 1000;
+    localStorage.setItem('ksat_timer_test@test.com_1', String(past));
+
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+
+    await waitFor(() => {
+      const timer = result.container.querySelector('.timer');
+      expect(timer.classList.contains('warning')).toBe(true);
+    });
+
+    vi.advanceTimersByTime(30 * 60 * 1000); // push past zero
+
+    await waitFor(() => {
+      const timer = result.container.querySelector('.timer');
+      expect(timer.classList.contains('over')).toBe(true);
+      expect(timer.classList.contains('warning')).toBe(false);
+    });
+  });
+});
+
+// ───────────────────────────────────────────────────────────
+// E. Edge cases
+// ───────────────────────────────────────────────────────────
+describe('Timer — edge cases', () => {
+  it('E1: no timer UI when exam has null duration_minutes', async () => {
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2026학년도');
+
+    expect(result.container.querySelector('.timer')).toBeNull();
+    expect(localStorage.getItem('ksat_timer_test@test.com_3')).toBeNull();
+  });
+
+  it('E2: no timer started when duration_minutes is 0', async () => {
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2027학년도');
+
+    expect(result.container.querySelector('.timer')).toBeNull();
+    expect(localStorage.getItem('ksat_timer_test@test.com_4')).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('E3: ignores corrupted non-numeric localStorage and starts fresh', async () => {
+    localStorage.setItem('ksat_timer_test@test.com_1', 'notanumber');
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+
+    expect(Number(localStorage.getItem('ksat_timer_test@test.com_1'))).toBe(BASE_TIME.getTime());
+  });
+});
+
+// ───────────────────────────────────────────────────────────
+// F. Lifecycle / leak prevention
+// ───────────────────────────────────────────────────────────
+describe('Timer — lifecycle', () => {
+  it('F1: onDestroy clears the interval on unmount', async () => {
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+    expect(vi.getTimerCount()).toBe(1);
+
+    result.unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('F2: switching exams does not accumulate intervals', async () => {
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+    expect(vi.getTimerCount()).toBe(1);
+
+    await fireEvent.click(result.getByRole('button', { name: /기출문제/ }));
+
+    await waitFor(() => {
+      expect(result.container.querySelector('.exam-list-item')).not.toBeNull();
+    });
+    const items = Array.from(result.container.querySelectorAll('.exam-list-item'));
+    const target = items.find((el) => el.textContent.includes('2024학년도'));
+    await fireEvent.click(target);
+
+    await waitFor(() => {
+      expect(result.container.querySelector('.essay-textarea')).not.toBeNull();
+    });
+
+    expect(vi.getTimerCount()).toBe(1);
+    // Separate localStorage namespaces
+    expect(localStorage.getItem('ksat_timer_test@test.com_1')).not.toBeNull();
+    expect(localStorage.getItem('ksat_timer_test@test.com_2')).not.toBeNull();
+  });
+
+  it('F3: repeated reset does not accumulate intervals', async () => {
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+
+    const resetBtn = result.container.querySelector('.timer-reset');
+    await fireEvent.click(resetBtn);
+    await fireEvent.click(resetBtn);
+    await fireEvent.click(resetBtn);
+
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it('F4: advancing time after unmount does not mutate localStorage', async () => {
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+    const before = localStorage.getItem('ksat_timer_test@test.com_1');
+
+    result.unmount();
+    vi.advanceTimersByTime(60 * 1000);
+
+    expect(localStorage.getItem('ksat_timer_test@test.com_1')).toBe(before);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────
+// G. Reset behaviour
+// ───────────────────────────────────────────────────────────
+describe('Timer — reset', () => {
+  it('G1: reset rewrites localStorage with current time', async () => {
+    const pastStart = BASE_TIME.getTime() - 30 * 60 * 1000;
+    localStorage.setItem('ksat_timer_test@test.com_1', String(pastStart));
+
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+    expect(Number(localStorage.getItem('ksat_timer_test@test.com_1'))).toBe(pastStart);
+
+    const resetBtn = result.container.querySelector('.timer-reset');
+    await fireEvent.click(resetBtn);
+
+    expect(Number(localStorage.getItem('ksat_timer_test@test.com_1'))).toBe(BASE_TIME.getTime());
+  });
+
+  it('G2: reset resets displayed time to the full duration', async () => {
+    const pastStart = BASE_TIME.getTime() - 100 * 60 * 1000; // 20 min left
+    localStorage.setItem('ksat_timer_test@test.com_1', String(pastStart));
+
+    const result = render(KSATFeedbackWriter);
+    await selectExamByTitle(result, '2025학년도');
+
+    await waitFor(() => {
+      expect(result.container.querySelector('.timer').classList.contains('warning')).toBe(true);
+    });
+
+    const resetBtn = result.container.querySelector('.timer-reset');
+    await fireEvent.click(resetBtn);
+
+    await waitFor(() => {
+      const timer = result.container.querySelector('.timer');
+      expect(timer.classList.contains('warning')).toBe(false);
+      expect(timer.querySelector('.timer-value').textContent.trim()).toBe('02:00:00');
+    });
+  });
+});

--- a/frontend/src/tests/routes/KSATFeedbackWriter.timer.test.js
+++ b/frontend/src/tests/routes/KSATFeedbackWriter.timer.test.js
@@ -142,12 +142,12 @@ describe('Timer — storage key', () => {
     expect(localStorage.getItem('ksat_timer_alice@example.com_1')).not.toBeNull();
   });
 
-  it('A2: falls back to ksat_timer_anon_{examId} when userEmail is empty', async () => {
+  it('A2: falls back to ksat_timer_anno_{examId} when userEmail is empty', async () => {
     mockUserEmail.set('');
     const result = render(KSATFeedbackWriter);
     await selectExamByTitle(result, '2025학년도');
 
-    expect(localStorage.getItem('ksat_timer_anon_1')).not.toBeNull();
+    expect(localStorage.getItem('ksat_timer_anno_1')).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- 답안 작성 탭에 남은 시간 카운트다운 UI 추가. 남은 시간 ≤ 30분이면 경고색(#c44536), 0초 이하가 되면 "시간 초과" 표시 + 깜빡임 애니메이션(`prefers-reduced-motion` 대응). Reset 버튼 포함.
- 시간 제한은 `Exam.duration_minutes` (nullable) 컬럼으로 모델·스키마·seed·seed 로더까지 일괄 추가. 기존 중앙대·인하대 인문 시험 전 행을 120분으로 마이그레이션에서 backfill.
- 시작 시각은 `localStorage[ksat_timer_{userEmail}_{examId}]`에 ms epoch로 저장 → 새로고침·탭 전환에도 이어지고 시험 전환 시 이전 interval 정리.
- 로그인 응답의 `email` 필드를 프론트가 `user_email`로 잘못 읽던 버그 동반 수정 (타이머의 per-user 스토리지 namespace가 영향받기 때문).

## Scope notes

- 답안 작성 탭에 **진입하는 순간** 타이머가 시작됨 (요구사항대로). 시험 선택 즉시 write 탭으로 전환되므로 동일 시점.
- 시간 초과 후에도 제출 버튼은 유지됨 (경고만). 요구사항대로.
- UUID 기반 익명 식별자는 out of scope — 익명 사용자 지원이 제품 스펙으로 확정되면 별도 PR에서 다룰 것.

## Test plan

### Backend (pytest)
- [ ] `test_exam_detail_includes_duration_minutes` — 상세 응답에 `duration_minutes` 직렬화 확인
- [ ] `test_exam_list_includes_duration_minutes` — 리스트 응답에도 포함
- [ ] `test_exam_duration_minutes_null_when_unset` — 값 미설정 시 `null` 회귀 방지
- [ ] `docker-compose exec backend bash ./scripts/test.sh` 전체 통과
- [ ] `alembic upgrade head` 후 기존 CAU/인하대 인문 exam들이 모두 `duration_minutes=120`

### Frontend (vitest, 18 cases in `KSATFeedbackWriter.timer.test.js`)
- [ ] A1/A2 — localStorage 키가 email 기반 + anon fallback
- [ ] B1/B2/B3 — 첫 선택 저장 / 기존 값 재개 / 탭 스위칭 간 불변
- [ ] C1/C2/C3 — `HH:MM:SS` / `MM:SS` / "시간 초과" 포맷
- [ ] D1/D2/D3 — 경고 임계값 진입 / 초과 전환 시 클래스 변화
- [ ] E1/E2/E3 — `duration_minutes` null/0 + 손상된 localStorage 방어
- [ ] F1/F2/F3/F4 — unmount / 시험 전환 / Reset 반복 시 interval 누수 없음
- [ ] G1/G2 — Reset 동작

### Manual UX
- [ ] CAU 인문 시험 선택 → 답안 작성 탭에서 `02:00:00` 표시
- [ ] 페이지 새로고침 → 경과 시간 이어짐
- [ ] Console에서 localStorage 값을 `Date.now() - 100*60*1000`으로 당김 + 재선택 → 경고색(20분 남음)
- [ ] `Date.now() - 125*60*1000` → 깜빡임 + "시간 초과"
- [ ] Reset 버튼 → 초기화

## Out of scope

- 로그아웃 시 `ksat_timer_*` 정리 (별도 정리 PR)
- 프론트 컨테이너 볼륨 마운트 (개발 편의 개선, 별도)
- 익명 사용자 세션·UUID 설계

🤖 Generated with [Claude Code](https://claude.com/claude-code)